### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ To install from [PyPi](https://pypi.python.org/pypi/pytextrank):
 
 ```
 pip install pytextrank
+python -m spacy download en_core_web_sm
 ```
 
 If you install directly from this Git repo, be sure to install the dependencies
@@ -96,6 +97,7 @@ as well:
 
 ```
 pip install -r requirements.txt
+python -m spacy download en_core_web_sm
 ```
 
 


### PR DESCRIPTION
I was just installing and then running the example from the READ.ME, and it would not run as it could not find the en_core_web_sm.
it is not a huge issue at all, but tis a simple thing to fix, if there are not reason to notdownload en_core_web_sm

Add this step before the Usage section.
Maybe after the pip install

> python -m spacy download en_core_web_sm