### PR TITLE
FIX #47: Add compatability to Python 3.x before Python 3.6

### DIFF
--- a/pytextrank/pytextrank.py
+++ b/pytextrank/pytextrank.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from collections import defaultdict 
+from collections import defaultdict, OrderedDict
 from math import sqrt
 from operator import itemgetter
 from spacy.tokens import Doc
@@ -225,7 +225,7 @@ class TextRank:
         self.lemma_graph = nx.Graph()
         self.phrases = defaultdict(list)
         self.ranks = {}
-        self.seen_lemma = {}
+        self.seen_lemma = OrderedDict()
 
 
     def load_stopwords (self, path="stop.json"):


### PR DESCRIPTION
https://github.com/DerwenAI/pytextrank/blob/ef00941c1ac62d02a91a57038c09f982857de3a9/pytextrank/pytextrank.py#L300

dict.keys() is not ordered prior to Python 3.6. So the line `node_id = list(self.seen_lemma.keys()).index(key)` would not work for older Python versions, and thus raising `KeyError`.

See: [PEP 468](https://www.python.org/dev/peps/pep-0468/#specification)
> dict in CPython 3.6 is now ordered, similar to PyPy.
