### PR TITLE
Add PositionRank

### DIFF
--- a/pytextrank/__init__.py
+++ b/pytextrank/__init__.py
@@ -1,1 +1,2 @@
 from .pytextrank import TextRank, Phrase, split_grafs, filter_quotes, maniacal_scrubber, default_scrubber
+from .positionrank import PositionRank

--- a/pytextrank/base.py
+++ b/pytextrank/base.py
@@ -1,0 +1,171 @@
+from collections import defaultdict, Counter
+from dataclasses import dataclass
+import itertools
+import math
+from typing import List, Tuple, Dict, Iterable, Set, Optional
+
+import networkx as nx
+from spacy.tokens import Doc, Span
+
+
+@dataclass
+class Phrase:
+    text: str
+    rank: float
+    count: int
+    phrase_list: List[Span]
+
+
+Node = Tuple[str, str]  # (lemma, pos)
+
+
+class BaseTextRank:
+    _EDGE_WEIGHT = 1.0
+    _POS_KEPT = ["ADJ", "NOUN", "PROPN", "VERB"]
+    _TOKEN_LOOKBACK = 3
+
+    def __init__(
+        self,
+        edge_weight=_EDGE_WEIGHT,
+        pos_kept=_POS_KEPT,
+        scrubber=str.strip,
+        token_lookback=_TOKEN_LOOKBACK,
+    ):
+        self.edge_weight = edge_weight
+        self.pos_kept = pos_kept
+        self.scrubber = scrubber
+        self.token_lookback = token_lookback
+
+        self.doc = None
+
+    def __call__(self, doc: Doc) -> Doc:
+        """Call the inner EntityRuler."""
+        self.doc = doc
+        Doc.set_extension("phrases", force=True, default=[])
+        Doc.set_extension("textrank", force=True, default=self)
+        doc._.phrases = self.calc_textrank()
+        return doc
+
+    def calc_textrank(self) -> List[Phrase]:
+        lemma_graph = self.construct_graph()
+
+        pagerank_personalization = self.get_personalization()
+
+        ranks: Dict[str, float] = nx.pagerank(
+            lemma_graph, personalization=pagerank_personalization
+        )
+
+        nc_phrases = self.collect_phrases(self.doc.noun_chunks, ranks)
+        ent_phrases = self.collect_phrases(self.doc.ents, ranks)
+        all_phrases = {**nc_phrases, **ent_phrases}
+
+        phrase_list: List[Phrase] = self.get_min_phrases(all_phrases)
+
+        return sorted(phrase_list, key=lambda p: p.rank, reverse=True)
+
+    def construct_graph(self) -> nx.Graph:
+        G = nx.Graph()
+        # add nodes made of (lemma, pos)
+        G.add_nodes_from(self.node_list)
+        # add edges between nodes co-occuring within a window, weighted by the count
+        G.add_edges_from(self.edge_list)
+        return G
+
+    @property
+    def node_list(self) -> List[Tuple[str, str]]:
+        nodes = [
+            (token.lemma_, token.pos_)
+            for token in self.doc
+            if token.pos_ in self.pos_kept
+        ]
+        return nodes
+
+    @property
+    def edge_list(self) -> List[Tuple[Node, Node, Dict[str, float]]]:
+        edges = []
+        for sent in self.doc.sents:
+            H = [
+                (token.lemma_, token.pos_)
+                for token in sent
+                if token.pos_ in self.pos_kept
+            ]
+            for hop in range(self.token_lookback):
+                for idx, node in enumerate(H[: -1 - hop]):
+                    nbor = H[hop + idx + 1]
+                    edges.append((node, nbor))
+
+        # Include weight on the edge: (2, 3, {'weight': 3.1415})
+        edges = [
+            (*n, dict(weight=w * self.edge_weight)) for n, w in Counter(edges).items()
+        ]
+        return edges
+
+    def get_personalization(self) -> Optional[Dict[Node, float]]:
+        return None
+
+    def collect_phrases(
+        self, spans: Iterable[Span], ranks: Dict[str, float]
+    ) -> Dict[Span, float]:
+        phrases = {
+            span: sum(
+                ranks[(token.lemma_, token.pos_)]
+                for token in span
+                if token.pos_ in self.pos_kept
+            )
+            for span in spans
+        }
+        return {
+            span: self._calc_discounted_normalised_rank(span, sum_rank)
+            for span, sum_rank in phrases.items()
+        }
+
+    def _calc_discounted_normalised_rank(self, span: Span, sum_rank: float) -> float:
+        non_lemma = len([tok for tok in span if tok.pos_ not in self.pos_kept])
+
+        # although the noun chunking is greedy, we discount the ranks using a
+        # point estimate based on the number of non-lemma tokens within a phrase
+        non_lemma_discount = len(span) / (len(span) + (2.0 * non_lemma) + 1.0)
+
+        # use root mean square (RMS) to normalize the contributions of all the tokens
+        phrase_rank = math.sqrt(sum_rank / (len(span) + non_lemma))
+
+        return phrase_rank * non_lemma_discount
+
+    def get_min_phrases(self, all_phrases=Dict[Span, float]) -> List[Phrase]:
+        data = [
+            (self.scrubber(span.text), rank, span) for span, rank in all_phrases.items()
+        ]
+
+        keyfunc = lambda x: x[0]
+        applyfunc = lambda g: list((rank, spans) for text, rank, spans in g)
+        phrases: List[Tuple[str, List[Tuple[float, Span]]]] = groupby_apply(
+            data, keyfunc, applyfunc
+        )
+
+        phrase_list = [
+            Phrase(
+                text=p[0],
+                rank=max(rank for rank, span in p[1]),
+                count=len(p[1]),
+                phrase_list=list(span for rank, span in p[1]),
+            )
+            for p in phrases
+        ]
+        return phrase_list
+
+
+def groupby_apply(data, keyfunc, applyfunc):
+    """Groupby a key and sum without pandas dependency.
+
+    Arguments:
+        data: iterable
+        keyfunc: callable to define the key by which you want to group
+        applyfunc: callable to apply to the group
+
+    Returns:
+        Iterable with accumulated values.
+
+    Ref: https://docs.python.org/3/library/itertools.html#itertools.groupby
+    """
+    data = sorted(data, key=keyfunc)
+    return [(k, applyfunc(g)) for k, g in itertools.groupby(data, keyfunc)]

--- a/pytextrank/base.py
+++ b/pytextrank/base.py
@@ -1,15 +1,35 @@
-from collections import defaultdict, Counter
-from dataclasses import dataclass
+"""Implements TextRank, with placeholder for bias."""
 import itertools
 import math
-from typing import List, Tuple, Dict, Iterable, Set, Optional
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 import networkx as nx
 from spacy.tokens import Doc, Span
 
 
+def groupby_apply(data: Iterable[Any], keyfunc: Callable, applyfunc: Callable) -> List[Tuple[Any, Any]]:
+    """Groupby a key and apply function without pandas dependency.
+
+    Arguments:
+        data: iterable
+        keyfunc: callable to define the key by which you want to group
+        applyfunc: callable to apply to the group
+
+    Returns:
+        Iterable with accumulated values.
+
+    Ref: https://docs.python.org/3/library/itertools.html#itertools.groupby
+    """
+    data = sorted(data, key=keyfunc)
+    return [(k, applyfunc(g)) for k, g in itertools.groupby(data, keyfunc)]
+
+
 @dataclass
 class Phrase:
+    """Holds data for extracted keyphrase."""
+
     text: str
     rank: float
     count: int
@@ -20,16 +40,18 @@ Node = Tuple[str, str]  # (lemma, pos)
 
 
 class BaseTextRank:
+    """Implements TextRank by Milhacea, et al., as a spaCy pipeline component."""
+
     _EDGE_WEIGHT = 1.0
     _POS_KEPT = ["ADJ", "NOUN", "PROPN", "VERB"]
     _TOKEN_LOOKBACK = 3
 
     def __init__(
         self,
-        edge_weight=_EDGE_WEIGHT,
-        pos_kept=_POS_KEPT,
-        scrubber=str.strip,
-        token_lookback=_TOKEN_LOOKBACK,
+        edge_weight: float = _EDGE_WEIGHT,
+        pos_kept: List[str] = _POS_KEPT,
+        scrubber: Callable = str.strip,
+        token_lookback: int = _TOKEN_LOOKBACK,
     ):
         self.edge_weight = edge_weight
         self.pos_kept = pos_kept
@@ -39,7 +61,7 @@ class BaseTextRank:
         self.doc = None
 
     def __call__(self, doc: Doc) -> Doc:
-        """Call the inner EntityRuler."""
+        """Run the spaCy pipeline component on the document."""
         self.doc = doc
         Doc.set_extension("phrases", force=True, default=[])
         Doc.set_extension("textrank", force=True, default=self)
@@ -47,11 +69,12 @@ class BaseTextRank:
         return doc
 
     def calc_textrank(self) -> List[Phrase]:
+        """Construct lemma graph and return top-ranked phrases."""
         lemma_graph = self.construct_graph()
 
         pagerank_personalization = self.get_personalization()
 
-        ranks: Dict[str, float] = nx.pagerank(
+        ranks: Dict[Node, float] = nx.pagerank(
             lemma_graph, personalization=pagerank_personalization
         )
 
@@ -64,6 +87,7 @@ class BaseTextRank:
         return sorted(phrase_list, key=lambda p: p.rank, reverse=True)
 
     def construct_graph(self) -> nx.Graph:
+        """Construct lemma graph."""
         G = nx.Graph()
         # add nodes made of (lemma, pos)
         G.add_nodes_from(self.node_list)
@@ -73,6 +97,7 @@ class BaseTextRank:
 
     @property
     def node_list(self) -> List[Tuple[str, str]]:
+        """Build list of vertices for the lemma graph."""
         nodes = [
             (token.lemma_, token.pos_)
             for token in self.doc
@@ -82,7 +107,8 @@ class BaseTextRank:
 
     @property
     def edge_list(self) -> List[Tuple[Node, Node, Dict[str, float]]]:
-        edges = []
+        """Build list of weighted edges  for the lemma graph."""
+        edges: List[Tuple[Node, Node]] = []
         for sent in self.doc.sents:
             H = [
                 (token.lemma_, token.pos_)
@@ -95,17 +121,19 @@ class BaseTextRank:
                     edges.append((node, nbor))
 
         # Include weight on the edge: (2, 3, {'weight': 3.1415})
-        edges = [
-            (*n, dict(weight=w * self.edge_weight)) for n, w in Counter(edges).items()
+        weighted_edges = [
+            (*n, {"weight": w * self.edge_weight}) for n, w in Counter(edges).items()
         ]
-        return edges
+        return weighted_edges
 
     def get_personalization(self) -> Optional[Dict[Node, float]]:
-        return None
+        """Get node weights for personalised PageRank."""
+        pass
 
     def collect_phrases(
-        self, spans: Iterable[Span], ranks: Dict[str, float]
+        self, spans: Iterable[Span], ranks: Dict[Node, float]
     ) -> Dict[Span, float]:
+        """Aggregate ranks of individual tokens within phrases."""
         phrases = {
             span: sum(
                 ranks[(token.lemma_, token.pos_)]
@@ -120,10 +148,11 @@ class BaseTextRank:
         }
 
     def _calc_discounted_normalised_rank(self, span: Span, sum_rank: float) -> float:
+        """Since the noun chunking is greedy, we discount the ranks using a
+        point estimate based on the number of non-lemma tokens within a phrase.
+        """
         non_lemma = len([tok for tok in span if tok.pos_ not in self.pos_kept])
 
-        # although the noun chunking is greedy, we discount the ranks using a
-        # point estimate based on the number of non-lemma tokens within a phrase
         non_lemma_discount = len(span) / (len(span) + (2.0 * non_lemma) + 1.0)
 
         # use root mean square (RMS) to normalize the contributions of all the tokens
@@ -131,7 +160,8 @@ class BaseTextRank:
 
         return phrase_rank * non_lemma_discount
 
-    def get_min_phrases(self, all_phrases=Dict[Span, float]) -> List[Phrase]:
+    def get_min_phrases(self, all_phrases: Dict[Span, float]) -> List[Phrase]:
+        """Group phrases by text, get max rank and collect spans in a list."""
         data = [
             (self.scrubber(span.text), rank, span) for span, rank in all_phrases.items()
         ]
@@ -152,20 +182,3 @@ class BaseTextRank:
             for p in phrases
         ]
         return phrase_list
-
-
-def groupby_apply(data, keyfunc, applyfunc):
-    """Groupby a key and sum without pandas dependency.
-
-    Arguments:
-        data: iterable
-        keyfunc: callable to define the key by which you want to group
-        applyfunc: callable to apply to the group
-
-    Returns:
-        Iterable with accumulated values.
-
-    Ref: https://docs.python.org/3/library/itertools.html#itertools.groupby
-    """
-    data = sorted(data, key=keyfunc)
-    return [(k, applyfunc(g)) for k, g in itertools.groupby(data, keyfunc)]

--- a/pytextrank/base.py
+++ b/pytextrank/base.py
@@ -33,7 +33,7 @@ class Phrase:
     text: str
     rank: float
     count: int
-    phrase_list: List[Span]
+    chunks: List[Span]
 
 
 Node = Tuple[str, str]  # (lemma, pos)
@@ -177,7 +177,7 @@ class BaseTextRank:
                 text=p[0],
                 rank=max(rank for rank, span in p[1]),
                 count=len(p[1]),
-                phrase_list=list(span for rank, span in p[1]),
+                chunks=list(span for rank, span in p[1]),
             )
             for p in phrases
         ]

--- a/pytextrank/positionrank.py
+++ b/pytextrank/positionrank.py
@@ -1,23 +1,29 @@
-"""Implementation of Florescu, et al. (2017) as a spaCy pipeline component."""
-import operator
-from typing import Optional, Dict, List, Tuple
+"""Implements PositionRank."""
+from typing import Dict, List, Optional, Tuple
 
-from .base import BaseTextRank, groupby_apply, Node
+from .base import BaseTextRank, Node, groupby_apply
 
 
 class PositionRank(BaseTextRank):
+    """Implements PositionRank by Florescu, et al. (2017) as a spaCy pipeline component."""
+
     def get_personalization(self) -> Optional[Dict[Node, float]]:
-        """
-        Specifically, we propose to assign a higher probability to a word
-        found on the 2nd position as compared with a word found on the
-        50th position in the same document. The weight of each candidate
-        word is equal to its inverse position in the document.
-        If the same word appears multiple times in the target document,
-        then we sum all its position weights.
-        For example, a word v_i occurring in the following positions:
-        2nd, 5th and 10th, has a weight p(v_i) = 1/2 + 1/5 + 1/10 = 4/5 = 0.8
-        The weights of words are normalized before they are used in the
-        position-biased PageRank.
+        """Get node weights for personalised PageRank.
+
+        Returns:
+            Biased restart probabilities for PageRank.
+
+        Reference:
+            > Specifically, we propose to assign a higher probability to a word
+            found on the 2nd position as compared with a word found on the
+            50th position in the same document. The weight of each candidate
+            word is equal to its inverse position in the document.
+            If the same word appears multiple times in the target document,
+            then we sum all its position weights.
+            For example, a word v_i occurring in the following positions:
+            2nd, 5th and 10th, has a weight p(v_i) = 1/2 + 1/5 + 1/10 = 4/5 = 0.8
+            The weights of words are normalized before they are used in the
+            position-biased PageRank.
         """
         weighted_tokens: List[Tuple[str, float]] = [
             (tok, 1 / (i + 1))

--- a/pytextrank/positionrank.py
+++ b/pytextrank/positionrank.py
@@ -47,6 +47,9 @@ class PositionRank(BaseTextRank):
         }
 
         weighted_nodes = {
+            # the authors assign higher probability to a word
+            # but our lemma graph vertices are (word, pos) tuples
+            # so we map each word weight to all vertices containing that word
             (token.lemma_, token.pos_): norm_weighted_tokens[token.lemma_]
             for token in self.doc
             if token.pos_ in self.pos_kept

--- a/pytextrank/positionrank.py
+++ b/pytextrank/positionrank.py
@@ -1,0 +1,48 @@
+"""Implementation of Florescu, et al. (2017) as a spaCy pipeline component."""
+import operator
+from typing import Optional, Dict, List, Tuple
+
+from .base import BaseTextRank, groupby_apply, Node
+
+
+class PositionRank(BaseTextRank):
+    def get_personalization(self) -> Optional[Dict[Node, float]]:
+        """
+        Specifically, we propose to assign a higher probability to a word
+        found on the 2nd position as compared with a word found on the
+        50th position in the same document. The weight of each candidate
+        word is equal to its inverse position in the document.
+        If the same word appears multiple times in the target document,
+        then we sum all its position weights.
+        For example, a word v_i occurring in the following positions:
+        2nd, 5th and 10th, has a weight p(v_i) = 1/2 + 1/5 + 1/10 = 4/5 = 0.8
+        The weights of words are normalized before they are used in the
+        position-biased PageRank.
+        """
+        weighted_tokens: List[Tuple[str, float]] = [
+            (tok, 1 / (i + 1))
+            for i, tok in enumerate(
+                token.lemma_ for token in self.doc if token.pos_ in self.pos_kept
+            )
+        ]
+
+        keyfunc = lambda x: x[0]
+        applyfunc = lambda g: sum(w for text, w in g)
+        accumulated_weighted_tokens: List[Tuple[str, float]] = groupby_apply(
+            weighted_tokens, keyfunc, applyfunc
+        )
+        accumulated_weighted_tokens = sorted(
+            accumulated_weighted_tokens, key=lambda x: x[1]
+        )
+
+        norm_weighted_tokens = {
+            k: w / sum(w_ for _, w_ in accumulated_weighted_tokens)
+            for k, w in accumulated_weighted_tokens
+        }
+
+        weighted_nodes = {
+            (token.lemma_, token.pos_): norm_weighted_tokens[token.lemma_]
+            for token in self.doc
+            if token.pos_ in self.pos_kept
+        }
+        return weighted_nodes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+import spacy
+from spacy.tokens import Doc
+
+
+@pytest.fixture(scope="session")
+def doc() -> Doc:
+    text = """
+    Chelsea 'opted against' signing Salomon Rondón on deadline day.
+
+    Chelsea reportedly opted against signing Salomón Rondón on deadline day despite their long search for a new centre forward.
+    With Olivier Giroud expected to leave, the Blues targeted Edinson Cavani, Dries Mertens and Moussa Dembele – only to end up with none of them.
+    According to Telegraph Sport, Dalian Yifang offered Rondón to Chelsea only for them to prefer keeping Giroud at the club.
+    Manchester United were also linked with the Venezuela international before agreeing a deal for Shanghai Shenhua striker Odion Ighalo.
+    Manager Frank Lampard made no secret of his transfer window frustration, hinting that to secure top four football he ‘needed’ signings.
+    Their draw against Leicester on Saturday means they have won just four of the last 13 Premier League matches.
+    """
+    nlp = spacy.load("en_core_web_sm")
+    doc = nlp(text)
+    return doc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,18 @@
 """Shared ficture functions."""
 import pytest
 import spacy
+from spacy.language import Language
 from spacy.tokens import Doc
 
 
 @pytest.fixture(scope="session")
-def doc() -> Doc:
+def nlp() -> Language:
+    nlp = spacy.load("en_core_web_sm")
+    return nlp
+
+
+@pytest.fixture(scope="session")
+def doc(nlp) -> Doc:
     """Doc shared ficture.
 
     Returns:
@@ -27,6 +34,5 @@ def doc() -> Doc:
     Their draw against Leicester on Saturday means they have won just four of the last
     13 Premier League matches.
     """
-    nlp = spacy.load("en_core_web_sm")
     doc = nlp(text)
     return doc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+"""Shared ficture functions."""
 import pytest
 import spacy
 from spacy.tokens import Doc
@@ -5,15 +6,26 @@ from spacy.tokens import Doc
 
 @pytest.fixture(scope="session")
 def doc() -> Doc:
+    """Doc shared ficture.
+
+    Returns:
+        spaCy EN doc containing a piece of football news.
+    """
     text = """
     Chelsea 'opted against' signing Salomon Rondón on deadline day.
 
-    Chelsea reportedly opted against signing Salomón Rondón on deadline day despite their long search for a new centre forward.
-    With Olivier Giroud expected to leave, the Blues targeted Edinson Cavani, Dries Mertens and Moussa Dembele – only to end up with none of them.
-    According to Telegraph Sport, Dalian Yifang offered Rondón to Chelsea only for them to prefer keeping Giroud at the club.
-    Manchester United were also linked with the Venezuela international before agreeing a deal for Shanghai Shenhua striker Odion Ighalo.
-    Manager Frank Lampard made no secret of his transfer window frustration, hinting that to secure top four football he ‘needed’ signings.
-    Their draw against Leicester on Saturday means they have won just four of the last 13 Premier League matches.
+    Chelsea reportedly opted against signing Salomón Rondón on deadline day despite
+    their long search for a new centre forward.
+    With Olivier Giroud expected to leave, the Blues targeted Edinson Cavani,
+    Dries Mertens and Moussa Dembele – only to end up with none of them.
+    According to Telegraph Sport, Dalian Yifang offered Rondón to Chelsea only for
+    them to prefer keeping Giroud at the club.
+    Manchester United were also linked with the Venezuela international before agreeing
+    a deal for Shanghai Shenhua striker Odion Ighalo.
+    Manager Frank Lampard made no secret of his transfer window frustration, hinting
+    that to secure top four football he ‘needed’ signings.
+    Their draw against Leicester on Saturday means they have won just four of the last
+    13 Premier League matches.
     """
     nlp = spacy.load("en_core_web_sm")
     doc = nlp(text)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Shared ficture functions."""
+"""Shared fixture functions."""
 import pytest
 import spacy
 from spacy.language import Language
@@ -7,13 +7,14 @@ from spacy.tokens import Doc
 
 @pytest.fixture(scope="session")
 def nlp() -> Language:
+    """Language shared fixture."""
     nlp = spacy.load("en_core_web_sm")
     return nlp
 
 
 @pytest.fixture(scope="session")
-def doc(nlp) -> Doc:
-    """Doc shared ficture.
+def doc(nlp: Language) -> Doc:
+    """Doc shared fixture.
 
     Returns:
         spaCy EN doc containing a piece of football news.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,30 @@
+import spacy
+
+from pytextrank.base import BaseTextRank
+
+
+def test_base_text_rank():
+    # given
+    text = """
+    roger martínez given second chance, may start against pumas.
+
+    roger martínez has become a real headache for the entire club américa time as there has been a debate for well over a month now about what the club should do with the player.
+    martínez had been holding out for a european move but when did not come, he turned down a pair of mls deals (rumoured to be in the range of $15m) to inter miami and los angeles galaxy – much to the chagrin of the américa heirarchy.
+    while there are many who support the notion to keep the colombian attacker frozen out of the squad, other fans say he should be forgiven – especially because up to nine other players could miss out due to injury or suspension.
+    on wednesday, it appears there was a change of heart in the américa camp as various sources, including espn, fox sports, and other major sports media, say that roger’s punishment has been lifted.
+    if this is true, the fact is that he would very likely start in the match against pumas this friday.
+    in training on wednesday, manager miguel herrera rehearsed with martínez as part of the starting squad, so everything that he will lead the line in the clásico capitalino.
+    since joining américa from villarreal, the 25-year-old has scored 17 goals and contributed 11 assists in 67 matches.
+    """
+    nlp = spacy.load("en_core_web_sm")
+    doc = nlp(text)
+    base_text_rank = BaseTextRank()
+
+    # when
+    processed_doc = base_text_rank(doc)
+    phrases = processed_doc._.phrases
+
+    # then
+    assert len(phrases)
+    assert len(set(p.text for p in phrases)) == len(phrases)
+    assert phrases[0].rank == max(p.rank for p in phrases)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 """Unit tests for BaseTextRank."""
+from spacy.language import Language
 from spacy.tokens import Doc
 
 from pytextrank.base import BaseTextRank
@@ -17,3 +18,22 @@ def test_base_text_rank(doc: Doc):
     assert len(phrases)
     assert len(set(p.text for p in phrases)) == len(phrases)
     assert phrases[0].rank == max(p.rank for p in phrases)
+
+
+def test_add_pipe(nlp: Language):
+    """It works as a pipeline components and can be disabled."""
+    # given
+    base_text_rank = BaseTextRank()
+    nlp.add_pipe(base_text_rank, name="textrank", last=True)    
+    text = "linear constraints over the"
+
+    # when
+    doc = nlp(text)
+
+    # then
+    assert len(doc._.phrases)
+
+    # when/then
+    with nlp.disable_pipes("textrank"):
+        doc = nlp(text)
+        assert len(doc._.phrases) == 0

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,11 @@
+"""Unit tests for BaseTextRank."""
+from spacy.tokens import Doc
+
 from pytextrank.base import BaseTextRank
 
 
-def test_base_text_rank(doc):
+def test_base_text_rank(doc: Doc):
+    """It ranks unique keywords in a document by decreasing centrality."""
     # given
     base_text_rank = BaseTextRank()
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,23 +1,8 @@
-import spacy
-
 from pytextrank.base import BaseTextRank
 
 
-def test_base_text_rank():
+def test_base_text_rank(doc):
     # given
-    text = """
-    roger martínez given second chance, may start against pumas.
-
-    roger martínez has become a real headache for the entire club américa time as there has been a debate for well over a month now about what the club should do with the player.
-    martínez had been holding out for a european move but when did not come, he turned down a pair of mls deals (rumoured to be in the range of $15m) to inter miami and los angeles galaxy – much to the chagrin of the américa heirarchy.
-    while there are many who support the notion to keep the colombian attacker frozen out of the squad, other fans say he should be forgiven – especially because up to nine other players could miss out due to injury or suspension.
-    on wednesday, it appears there was a change of heart in the américa camp as various sources, including espn, fox sports, and other major sports media, say that roger’s punishment has been lifted.
-    if this is true, the fact is that he would very likely start in the match against pumas this friday.
-    in training on wednesday, manager miguel herrera rehearsed with martínez as part of the starting squad, so everything that he will lead the line in the clásico capitalino.
-    since joining américa from villarreal, the 25-year-old has scored 17 goals and contributed 11 assists in 67 matches.
-    """
-    nlp = spacy.load("en_core_web_sm")
-    doc = nlp(text)
     base_text_rank = BaseTextRank()
 
     # when

--- a/tests/test_positionrank.py
+++ b/tests/test_positionrank.py
@@ -5,7 +5,7 @@ from pytextrank.base import BaseTextRank
 from pytextrank.positionrank import PositionRank
 
 
-def test_base_text_rank(doc: Doc):
+def test_position_rank(doc: Doc):
     """It ranks keywords that appear early in the document higher than TextRank."""
     # given
     position_rank = PositionRank()

--- a/tests/test_positionrank.py
+++ b/tests/test_positionrank.py
@@ -1,8 +1,12 @@
-from pytextrank.positionrank import PositionRank
+"""Unit tests for PositionRank."""
+from spacy.tokens import Doc
+
 from pytextrank.base import BaseTextRank
+from pytextrank.positionrank import PositionRank
 
 
-def test_base_text_rank(doc):
+def test_base_text_rank(doc: Doc):
+    """It ranks keywords that appear early in the document higher than TextRank."""
     # given
     position_rank = PositionRank()
     base_text_rank = BaseTextRank()
@@ -21,5 +25,5 @@ def test_base_text_rank(doc):
     # with PositionRank, the situation is the opposite, which is desired for a piece of news.
     assert "Chelsea" in [p.text for p in phrases[:10]]
     assert "Chelsea" not in [p.text for p in comparison_phrases[:10]]
-    assert 'Shanghai Shenhua' not in [p.text for p in phrases[:10]]
-    assert 'Shanghai Shenhua' in [p.text for p in comparison_phrases[:10]]
+    assert "Shanghai Shenhua" not in [p.text for p in phrases[:10]]
+    assert "Shanghai Shenhua" in [p.text for p in comparison_phrases[:10]]

--- a/tests/test_positionrank.py
+++ b/tests/test_positionrank.py
@@ -1,0 +1,25 @@
+from pytextrank.positionrank import PositionRank
+from pytextrank.base import BaseTextRank
+
+
+def test_base_text_rank(doc):
+    # given
+    position_rank = PositionRank()
+    base_text_rank = BaseTextRank()
+
+    # when
+    processed_doc = position_rank(doc)
+    phrases = processed_doc._.phrases
+    comparison_doc = base_text_rank(doc)
+    comparison_phrases = comparison_doc._.phrases
+
+    # then
+    assert set(p.rank for p in phrases) != set(p.rank for p in comparison_phrases)
+    # the test article mentions Chelsea at the begginning of the article
+    # while it mentions Shanghai Shenhua annecdotally later in the article
+    # with normal TextRank, Shanghai Shenhua is part of top 10 phrases and Chelsea is not
+    # with PositionRank, the situation is the opposite, which is desired for a piece of news.
+    assert "Chelsea" in [p.text for p in phrases[:10]]
+    assert "Chelsea" not in [p.text for p in comparison_phrases[:10]]
+    assert 'Shanghai Shenhua' not in [p.text for p in phrases[:10]]
+    assert 'Shanghai Shenhua' in [p.text for p in comparison_phrases[:10]]


### PR DESCRIPTION
In this PR, I add support for PositionRank as discussed in #78.

This change includes:
- a refactored TextRank that lives separately from the current module, and that allows for inheritance with different bias functions
- a new pipeline component PositionRank that implements Florescu, et al. (2017)
- pytest tests for both

I formatted the code with black and type annotated, using my usual linting setup.

What do you think about the classes and the overall design?
I am afraid I might be using too many list comprehensions (I saw https://twitter.com/pacoid/status/1349862509772111872 😂 )
also afraid that the `pytextrank.pytextrank` module was not really reused... I did reuse its naming though.
Let me know your thoughts, I'm flexible and can change approaches.

## TODO:

Notes for after the discussion

- [ ] get feedback on the design
  - [ ] is there further python we can do to make the inheritance clearer: maybe with `abc.abstractmethod` to show that a "TextRank flavour" would reimplement the `node_list`, `edge_list`, `get_personalization` methods etc...
  - [ ] can I make the missing rows from my table in #78 more apparent in the base class? e.g. "Document Parse", "Restart probas for pagerank" (could be a better name for gt_personalization), "Candidate generation"
- [ ] do we need further tests (reproducing the paper results with the metric?) or is it fine like that?
- [ ] include the pytest command as part of the Readme for the development setup
- [ ] do I need to include summarization in my change?
- [ ] we rely on the fact that `doc` is not None, should I add checks and raise a custom exception?