### PR TITLE
add preserve_order to TextRank.summary

### DIFF
--- a/pytextrank/pytextrank.py
+++ b/pytextrank/pytextrank.py
@@ -458,7 +458,7 @@ class TextRank:
             f.write(dot.source)
 
 
-    def summary (self, limit_phrases=10, limit_sentences=4):
+    def summary (self, limit_phrases=10, limit_sentences=4, preserve_order=False):
         """
         run extractive summarization, based on vector distance 
         per sentence from the top-ranked phrases
@@ -535,16 +535,19 @@ class TextRank:
             sent_text[sent_id] = sent
             sent_id += 1
 
+        # build a list of sentence indices, sorted according to their
+        # corresponding rank
+        top_sent_ids = list(range(len(sent_rank)))
+        top_sent_ids.sort(key=lambda sent_id: sent_rank[sent_id])
+        # truncate to the given limit
+        top_sent_ids = top_sent_ids[:limit_sentences]
+        # sort in ascending order of index to preserve the order in which the
+        # sentences appear in the original text
+        if preserve_order:
+            top_sent_ids.sort()
         # yield results, up to the limit requested
-
-        num_sent = 0
-
-        for sent_id, rank in sorted(sent_rank.items(), key=itemgetter(1)):
+        for sent_id in top_sent_ids:
             yield sent_text[sent_id]
-            num_sent += 1
-
-            if num_sent == limit_sentences:
-                break
 
 
     def PipelineComponent (self, doc):


### PR DESCRIPTION
For my application, I was synopsizing fiction texts. For that application, and I imagine for other consumers of this package who might wish to synopsize other forms of narrative, it was a pain point for me to have to sort the sentences again in order of appearance once they had already been output in descending order of topical centrality. I created a parameter that allows summarization to be configured at the call-site to output either most topical sentences first, _or_ output the top-k most topical sentences in the order that they originally appeared. 