### PR TITLE
fix issue 'doc._.textrank.summary bug when used on multiple docs #69'

### DIFF
--- a/pytextrank/__init__.py
+++ b/pytextrank/__init__.py
@@ -1,6 +1,6 @@
-from .base import BaseTextRank, Lemma, Phrase, Sentence, VectorElem
+from .base import BaseTextRankFactory, Lemma, Phrase, Sentence, VectorElem
 
-from .positionrank import PositionRank
+from .positionrank import PositionRankFactory
 
 from .util import groupby_apply, default_scrubber, maniacal_scrubber, split_grafs, filter_quotes
 
@@ -15,9 +15,9 @@ import typing
 
 
 _DEFAULT_CONFIG = {
-    "edge_weight": BaseTextRank._EDGE_WEIGHT,  # pylint: disable=W0212
-    "pos_kept": BaseTextRank._POS_KEPT,  # pylint: disable=W0212
-    "token_lookback": BaseTextRank._TOKEN_LOOKBACK,  # pylint: disable=W0212
+    "edge_weight": BaseTextRankFactory._EDGE_WEIGHT,  # pylint: disable=W0212
+    "pos_kept": BaseTextRankFactory._POS_KEPT,  # pylint: disable=W0212
+    "token_lookback": BaseTextRankFactory._TOKEN_LOOKBACK,  # pylint: disable=W0212
     "scrubber": None,
     }
 
@@ -30,11 +30,11 @@ def _create_component_tr (
     pos_kept: typing.List[str],
     token_lookback: int,
     scrubber: typing.Optional[typing.Callable],
-    ) -> BaseTextRank:
+    ) -> BaseTextRankFactory:
     """
 Component factory for the `TextRank` base class.
     """
-    return BaseTextRank(
+    return BaseTextRankFactory(
         edge_weight = edge_weight,
         pos_kept = pos_kept,
         token_lookback = token_lookback,
@@ -49,11 +49,11 @@ def _create_component_pr (
     pos_kept: typing.List[str],
     token_lookback: int,
     scrubber: typing.Optional[typing.Callable],
-    ) -> BaseTextRank:
+    ) -> PositionRankFactory:
     """
 Component factory for the `PositionRank` extended class.
     """
-    return PositionRank(
+    return PositionRankFactory(
         edge_weight = edge_weight,
         pos_kept = pos_kept,
         token_lookback = token_lookback,

--- a/pytextrank/positionrank.py
+++ b/pytextrank/positionrank.py
@@ -3,9 +3,11 @@ Implements the *PositionRank* algorithm.
 """
 
 import typing
-from .base import BaseTextRank, Lemma
+from .base import BaseTextRankFactory, BaseTextRank, Lemma
 from .util import groupby_apply
 
+class PositionRankFactory(BaseTextRankFactory):
+    pass
 
 class PositionRank (BaseTextRank):
     """

--- a/pytextrank/positionrank.py
+++ b/pytextrank/positionrank.py
@@ -3,11 +3,34 @@ Implements the *PositionRank* algorithm.
 """
 
 import typing
+from spacy.tokens import Doc
 from .base import BaseTextRankFactory, BaseTextRank, Lemma
 from .util import groupby_apply
 
 class PositionRankFactory(BaseTextRankFactory):
     pass
+
+    def __call__(self,doc: Doc,) -> Doc:
+        """
+        Set the extension attributes on a `spaCy` [`Doc`](https://spacy.io/api/doc)
+        document to create a *pipeline component* for `PositionRank` as
+        a stateful component, invoked when the document gets processed.
+        See: <https://spacy.io/usage/processing-pipelines#pipelines>
+
+            doc:
+        a document container for accessing the annotations produced by earlier
+        stages of the `spaCy` pipeline
+        """
+
+        Doc.set_extension("textrank", force=True, default=None)
+        Doc.set_extension("phrases", force=True, default=[])
+        doc._.textrank = PositionRank(doc, edge_weight=self.edge_weight,
+                                      pos_kept=self.pos_kept,
+                                      token_lookback=self.token_lookback,
+                                      scrubber=self.scrubber, )
+        doc._.phrases = doc._.textrank.calc_textrank()
+        return doc
+
 
 class PositionRank (BaseTextRank):
     """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,13 +3,13 @@ from spacy.language import Language
 from spacy.tokens import Doc
 
 import sys ; sys.path.insert(0, "../pytextrank")
-from pytextrank.base import BaseTextRank
+from pytextrank.base import BaseTextRankFactory
 
 
 def test_base_text_rank (doc: Doc):
     """It ranks unique keywords in a document, sorted decreasing by centrality."""
     # given
-    base_text_rank = BaseTextRank()
+    base_text_rank = BaseTextRankFactory()
 
     # when
     processed_doc = base_text_rank(doc)
@@ -24,7 +24,7 @@ def test_base_text_rank (doc: Doc):
 def test_add_pipe (nlp: Language):
     """It works as a pipeline component and can be disabled."""
     # given
-    base_text_rank = BaseTextRank()
+    # base_text_rank = BaseTextRankFactory()
     nlp.add_pipe("textrank", last=True)
 
     # works as a pipeline component
@@ -80,7 +80,7 @@ def test_summary (nlp: Language):
         [17, [2]],
         ]
 
-    with open("dat/lee.txt", "r") as f:
+    with open("../dat/lee.txt", "r") as f:
         text = f.read()
         doc = nlp(text)
         tr = doc._.textrank

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -95,3 +95,33 @@ def test_summary (nlp: Language):
 
         # then
         assert trace == expected_trace
+
+
+def test_multiple_summary(nlp: Language):
+    """
+    Summarization produces consistent results when called upon multiple docs
+    """
+    texts = []
+    with open("../dat/lee.txt", "r") as f:
+        text = f.read()
+        texts.append(text)
+
+    with open("../dat/mih.txt", "r") as f:
+        text = f.read()
+        texts.append(text)
+
+    docs = [nlp(text) for text in texts]
+
+    trace1 = [
+        [sent_dist.sent_id, list(sent_dist.phrases)]
+        for sent_dist in docs[0]._.textrank.calc_sent_dist(limit_phrases=10)
+        if not sent_dist.empty()
+    ]
+
+    trace2 = [
+        [sent_dist.sent_id, list(sent_dist.phrases)]
+        for sent_dist in docs[1]._.textrank.calc_sent_dist(limit_phrases=10)
+        if not sent_dist.empty()
+    ]
+
+    assert trace1 != trace2

--- a/tests/test_positionrank.py
+++ b/tests/test_positionrank.py
@@ -2,15 +2,15 @@
 from spacy.tokens import Doc
 
 import sys ; sys.path.insert(0, "../pytextrank")
-from pytextrank.base import BaseTextRank
-from pytextrank.positionrank import PositionRank
+from pytextrank.base import BaseTextRankFactory
+from pytextrank.positionrank import PositionRankFactory
 
 
 def test_position_rank (doc: Doc):
     """It ranks keywords that appear early in the document higher than TextRank."""
     # given
-    position_rank = PositionRank()
-    base_text_rank = BaseTextRank()
+    position_rank = PositionRankFactory()
+    base_text_rank = BaseTextRankFactory()
 
     # when
     processed_doc = position_rank(doc)


### PR DESCRIPTION
As per https://github.com/DerwenAI/pytextrank/issues/69 I see that every doc was being assigned same BaseTextrank object which was remembering only last doc on which nlp pipeline was called. I added a factory class that assigns each doc it"s own Textrank object.

Please review code and suggest improvements. 