### PR TITLE
Add biasedtextrank module.

### DIFF
--- a/docs/biblio.md
+++ b/docs/biblio.md
@@ -45,6 +45,15 @@ open: <https://www.cs.purdue.edu/homes/dgleich/publications/Gleich%202015%20-%20
 *arXiv* (2020)
 
 
+## – K –
+
+### kazemi2011corr
+
+["Biased TextRank: Unsupervised Graph-Based Content Extraction"](https://arxiv.org/abs/2011.01026)  
+**Ashkan Kazemi**, **Verónica Pérez-Rosas**, **Rada Mihalcea**  
+*CoRR* (2011)
+
+
 ## – P –
 
 ### page1998

--- a/pkg_doc.py
+++ b/pkg_doc.py
@@ -21,6 +21,8 @@ if __name__ == "__main__":
         "BaseTextRank",
         "PositionRankFactory",
         "PositionRank",
+        "BiasedTextRankFactory",
+        "BiasedTextRank",
         "Lemma",
         "Phrase",
         "Sentence",

--- a/pytextrank/__init__.py
+++ b/pytextrank/__init__.py
@@ -3,6 +3,7 @@ from .base import BaseTextRankFactory, BaseTextRank, Lemma, Phrase, Sentence, Ve
 from .positionrank import PositionRankFactory, PositionRank
 
 from .biasedrank import BiasedTextRankFactory, BiasedTextRank
+
 from .util import groupby_apply, default_scrubber, maniacal_scrubber, split_grafs, filter_quotes
 
 from .version import MIN_PY_VERSION, _versify, _check_version, __version__
@@ -70,7 +71,7 @@ Component factory for the `PositionRank` extended class.
 
 
 @Language.factory("biasedtextrank", default_config=_DEFAULT_CONFIG)
-def _create_component_pr (
+def _create_component_br (
     nlp: Language,  # pylint: disable=W0613
     name: str,  # pylint: disable=W0613
     edge_weight: float,

--- a/pytextrank/__init__.py
+++ b/pytextrank/__init__.py
@@ -2,6 +2,7 @@ from .base import BaseTextRankFactory, BaseTextRank, Lemma, Phrase, Sentence, Ve
 
 from .positionrank import PositionRankFactory, PositionRank
 
+from .biasedrank import BiasedTextRankFactory, BiasedTextRank
 from .util import groupby_apply, default_scrubber, maniacal_scrubber, split_grafs, filter_quotes
 
 from .version import MIN_PY_VERSION, _versify, _check_version, __version__
@@ -60,6 +61,28 @@ def _create_component_pr (
 Component factory for the `PositionRank` extended class.
     """
     return PositionRankFactory(
+        edge_weight = edge_weight,
+        pos_kept = pos_kept,
+        token_lookback = token_lookback,
+        scrubber = scrubber,
+        stopwords = stopwords,
+        )
+
+
+@Language.factory("biasedtextrank", default_config=_DEFAULT_CONFIG)
+def _create_component_pr (
+    nlp: Language,  # pylint: disable=W0613
+    name: str,  # pylint: disable=W0613
+    edge_weight: float,
+    pos_kept: typing.List[str],
+    token_lookback: int,
+    scrubber: typing.Optional[typing.Callable],
+    stopwords: typing.Optional[StopWordsLike],
+    ) -> BiasedTextRankFactory:
+    """
+Component factory for the `BiasedTextRank` extended class.
+    """
+    return BiasedTextRankFactory(
         edge_weight = edge_weight,
         pos_kept = pos_kept,
         token_lookback = token_lookback,

--- a/pytextrank/biasedrank.py
+++ b/pytextrank/biasedrank.py
@@ -1,0 +1,193 @@
+"""
+Implements the *BiasedTextrank* algorithm.
+"""
+import time
+
+from spacy.tokens import Doc, Span, Token  # type: ignore
+import typing
+import networkx as nx  # type: ignore
+
+from .base import BaseTextRankFactory, BaseTextRank, Lemma, Phrase, Sentence
+from .util import groupby_apply
+
+
+class BiasedTextRankFactory (BaseTextRankFactory):
+    """
+A factory class that provides the document with its instance of
+`PositionRank`
+    """
+
+
+    def __call__ (
+        self,
+        doc: Doc,
+        ) -> Doc:
+        """
+Set the extension attributes on a `spaCy` [`Doc`](https://spacy.io/api/doc)
+document to create a *pipeline component* for `PositionRank` as
+a stateful component, invoked when the document gets processed.
+
+See: <https://spacy.io/usage/processing-pipelines#pipelines>
+
+    doc:
+a document container, providing the annotations produced by earlier stages of the `spaCy` pipeline
+        """
+        Doc.set_extension("textrank", force=True, default=None)
+        Doc.set_extension("phrases", force=True, default=[])
+
+        doc._.textrank = BiasedTextRank(
+            doc,
+            edge_weight = self.edge_weight,
+            pos_kept = self.pos_kept,
+            token_lookback = self.token_lookback,
+            scrubber = self.scrubber,
+            stopwords = self.stopwords,
+            )
+
+        return doc
+
+
+class BiasedTextRank(BaseTextRank):
+    """
+Implements the *PositionRank* algorithm described by
+[[florescuc17]](https://derwen.ai/docs/ptr/biblio/#florescuc17),
+deployed as a `spaCy` pipeline component.
+
+This class does not get called directly; instantiate its factory
+instead.
+    """
+
+
+    def get_personalization (
+        self, focus=None, bias=1
+        ) -> typing.Optional[typing.Dict[Lemma, float]]:
+        """
+        Get the *node weights* for initializing the use of the
+        [*Personalized PageRank*](https://derwen.ai/docs/ptr/glossary/#personalized-pagerank)
+        algorithm.
+
+            returns:
+        Biased restart probabilities to use in the *PageRank* algorithm.
+        """
+        focus_tokens = focus.lower().split(" ")
+        # assign bias to focus nodes while 1 to other nodes
+        weighted_nodes = {
+            Lemma(token.lemma_, token.pos_): bias if token.text in focus_tokens or token.lemma_ in focus_tokens else 1
+            for token in self.doc
+            if token.pos_ in self.pos_kept
+        }
+
+        # normalize weights
+        total_weight = sum([weight for weight in weighted_nodes.values()])
+        if total_weight ==0:
+            return None
+        normalized_weighted_nodes = {lemma : weight/total_weight for lemma, weight in weighted_nodes.items()}
+
+        # print(f"normalized_weighted_nodes: {normalized_weighted_nodes}")
+        return normalized_weighted_nodes
+
+    def calc_textrank(
+                self,
+            focus="",
+            bias=1
+        ):
+            """
+    Iterate through each sentence in the doc, constructing a
+    [*lemma graph*](https://derwen.ai/docs/ptr/glossary/#lemma-graph)
+
+    This method represents the heart of the *TextRank* algorithm.
+
+        returns: None
+            """
+            t0 = time.time()
+            self.reset()
+            self.lemma_graph = self._construct_graph()
+
+            # to run the algorithm, we use the NetworkX implementation
+            # of PageRank (i.e., approximating eigenvalue centrality)
+            # to calculate a rank for each node in the lemma graph
+            personalization = self.get_personalization(focus, bias)
+            self.ranks = nx.pagerank(
+                self.lemma_graph,
+                personalization=personalization,
+            )
+
+            # agglomerate the lemmas ranked in the lemma graph into ranked
+            # phrases, leveraging information from earlier stages of the
+            # pipeline: noun chunks and named entities
+
+            nc_phrases: typing.Dict[Span, float] = self._collect_phrases(self.doc.noun_chunks, self.ranks)
+            ent_phrases: typing.Dict[Span, float] = self._collect_phrases(self.doc.ents, self.ranks)
+            all_phrases: typing.Dict[Span, float] = {**nc_phrases, **ent_phrases}
+
+            # since noun chunks can be expressed in different ways (e.g., may
+            # have articles or prepositions), we need to find a minimum span
+            # for each phrase based on combinations of lemmas
+            raw_phrase_list: typing.List[Phrase] = self._get_min_phrases(all_phrases)
+            phrase_list: typing.List[Phrase] = sorted(raw_phrase_list, key=lambda p: p.rank, reverse=True)
+
+            t1 = time.time()
+            self.elapsed_time = (t1 - t0) * 1000.0
+            self.phrases = phrase_list
+
+    def get_phrases(self, focus="", bias=1) -> typing.List[Phrase]:
+        """
+        returns:
+        list of ranked phrases, in descending order
+        """
+        t0 = time.time()
+        # calculate textrank
+        self.calc_textrank(focus, bias)
+        return self.phrases
+
+
+    def summary (
+        self,
+        *,
+        focus="",
+        bias=1,
+        limit_phrases: int = 10,
+        limit_sentences: int = 4,
+        preserve_order: bool = False,
+        ) -> typing.Iterator[str]:
+        """
+Run an
+[*extractive summarization*](https://derwen.ai/docs/ptr/glossary/#extractive-summarization),
+based on the vector distance (per sentence) for each of the top-ranked phrases.
+
+    limit_phrases:
+maximum number of top-ranked phrases to use in the distance vectors
+
+    limit_sentences:
+total number of sentences to yield for the extractive summarization
+
+    preserve_order:
+flag to preserve the order of sentences as they originally occurred in the source text; defaults to `False`
+
+    yields:
+texts for sentences, in order
+        """
+        # calculate textrank
+        self.calc_textrank(focus, bias)
+
+        # build a list of sentence indices sorted by distance
+        sent_dist: typing.List[Sentence] = self.calc_sent_dist(limit_phrases)
+
+        top_sent_ids: typing.List[int] = [
+            sent.sent_id
+            for sent in sorted(sent_dist, key=lambda sent: sent.distance)
+            ]
+
+        # truncated to the specified limit
+        limit = min(limit_sentences, len(top_sent_ids))
+        top_sent_ids = top_sent_ids[:limit]
+
+        # optional: sort in ascending order of index to preserve the
+        # order in which sentences appear in the original text
+        if preserve_order:
+            top_sent_ids.sort()
+
+        # extract sentences with the least distance, up to the limit
+        # requested
+        for sent_id in top_sent_ids:
+            yield sent_dist[sent_id].text(self.doc)

--- a/pytextrank/biasedrank.py
+++ b/pytextrank/biasedrank.py
@@ -1,22 +1,18 @@
 """
 Implements the *BiasedTextrank* algorithm.
 """
-import time
 
-from spacy.tokens import Doc, Span, Token  # type: ignore
+from spacy.tokens import Doc, Token  # type: ignore
 import typing
-import networkx as nx  # type: ignore
 
-from .base import BaseTextRankFactory, BaseTextRank, Lemma, Phrase, Sentence
-from .util import groupby_apply
+from .base import BaseTextRankFactory, BaseTextRank, Lemma, Phrase
 
 
 class BiasedTextRankFactory (BaseTextRankFactory):
     """
 A factory class that provides the document with its instance of
-`PositionRank`
+`BiasedTextRank`
     """
-
 
     def __call__ (
         self,
@@ -24,7 +20,7 @@ A factory class that provides the document with its instance of
         ) -> Doc:
         """
 Set the extension attributes on a `spaCy` [`Doc`](https://spacy.io/api/doc)
-document to create a *pipeline component* for `PositionRank` as
+document to create a *pipeline component* for `BiasedTextRank` as
 a stateful component, invoked when the document gets processed.
 
 See: <https://spacy.io/usage/processing-pipelines#pipelines>
@@ -44,150 +40,104 @@ a document container, providing the annotations produced by earlier stages of th
             stopwords = self.stopwords,
             )
 
+        doc._.phrases = doc._.textrank.calc_textrank()
         return doc
 
 
-class BiasedTextRank(BaseTextRank):
+class BiasedTextRank (BaseTextRank):
     """
-Implements the *PositionRank* algorithm described by
-[[florescuc17]](https://derwen.ai/docs/ptr/biblio/#florescuc17),
+Implements the *Biased TextRank* algorithm described by
+[[kazemi2011corr]](https://derwen.ai/docs/ptr/biblio/#kazemi2011corr),
 deployed as a `spaCy` pipeline component.
 
 This class does not get called directly; instantiate its factory
 instead.
     """
 
+    _NODE_BIAS: float = 1.0
+
+
+    def _get_node_bias (
+        self,
+        token: Token,
+        ) -> float:
+        """
+Assign the bias to use, where focus nodes get the preset bias and
+other nodes get the default (`1.0`) value.
+
+    token:
+`spaCy` token to use for lookup in the focus set
+
+    returns:
+bias to apply for the *node weight*
+        """
+        if token.text in self.focus_tokens:
+            return self.node_bias
+
+        if token.lemma_ in self.focus_tokens:
+            return self.node_bias
+
+        return self._NODE_BIAS
+
 
     def get_personalization (
-        self, focus=None, bias=1
+        self,
         ) -> typing.Optional[typing.Dict[Lemma, float]]:
         """
-        Get the *node weights* for initializing the use of the
-        [*Personalized PageRank*](https://derwen.ai/docs/ptr/glossary/#personalized-pagerank)
-        algorithm.
+Get the *node weights* for initializing the use of the
+[*Personalized PageRank*](https://derwen.ai/docs/ptr/glossary/#personalized-pagerank)
+algorithm.
 
-            returns:
-        Biased restart probabilities to use in the *PageRank* algorithm.
+    returns:
+biased restart probabilities to use in the *PageRank* algorithm.
         """
-        focus_tokens = focus.lower().split(" ")
-        # assign bias to focus nodes while 1 to other nodes
-        weighted_nodes = {
-            Lemma(token.lemma_, token.pos_): bias if token.text in focus_tokens or token.lemma_ in focus_tokens else 1
+        # TODO: lookup bias based on (lemma, pos) instead, similar to *PositionRank*?
+        weighted_nodes: typing.Dict[Lemma, float] = {
+            Lemma(token.lemma_, token.pos_): self._get_node_bias(token)
             for token in self.doc
             if token.pos_ in self.pos_kept
         }
 
         # normalize weights
-        total_weight = sum([weight for weight in weighted_nodes.values()])
-        if total_weight ==0:
-            return None
-        normalized_weighted_nodes = {lemma : weight/total_weight for lemma, weight in weighted_nodes.items()}
+        total_weight = sum(weighted_nodes.values())
 
-        # print(f"normalized_weighted_nodes: {normalized_weighted_nodes}")
+        if total_weight == 0.0:
+            return None
+
+        normalized_weighted_nodes: typing.Dict[Lemma, float] = {
+            lemma : weight / total_weight
+            for lemma, weight in weighted_nodes.items()
+            }
+
         return normalized_weighted_nodes
 
-    def calc_textrank(
-                self,
-            focus="",
-            bias=1
-        ):
-            """
-    Iterate through each sentence in the doc, constructing a
-    [*lemma graph*](https://derwen.ai/docs/ptr/glossary/#lemma-graph)
 
-    This method represents the heart of the *TextRank* algorithm.
-
-        returns: None
-            """
-            t0 = time.time()
-            self.reset()
-            self.lemma_graph = self._construct_graph()
-
-            # to run the algorithm, we use the NetworkX implementation
-            # of PageRank (i.e., approximating eigenvalue centrality)
-            # to calculate a rank for each node in the lemma graph
-            personalization = self.get_personalization(focus, bias)
-            self.ranks = nx.pagerank(
-                self.lemma_graph,
-                personalization=personalization,
-            )
-
-            # agglomerate the lemmas ranked in the lemma graph into ranked
-            # phrases, leveraging information from earlier stages of the
-            # pipeline: noun chunks and named entities
-
-            nc_phrases: typing.Dict[Span, float] = self._collect_phrases(self.doc.noun_chunks, self.ranks)
-            ent_phrases: typing.Dict[Span, float] = self._collect_phrases(self.doc.ents, self.ranks)
-            all_phrases: typing.Dict[Span, float] = {**nc_phrases, **ent_phrases}
-
-            # since noun chunks can be expressed in different ways (e.g., may
-            # have articles or prepositions), we need to find a minimum span
-            # for each phrase based on combinations of lemmas
-            raw_phrase_list: typing.List[Phrase] = self._get_min_phrases(all_phrases)
-            phrase_list: typing.List[Phrase] = sorted(raw_phrase_list, key=lambda p: p.rank, reverse=True)
-
-            t1 = time.time()
-            self.elapsed_time = (t1 - t0) * 1000.0
-            self.phrases = phrase_list
-
-    def get_phrases(self, focus="", bias=1) -> typing.List[Phrase]:
-        """
-        returns:
-        list of ranked phrases, in descending order
-        """
-        t0 = time.time()
-        # calculate textrank
-        self.calc_textrank(focus, bias)
-        return self.phrases
-
-
-    def summary (
+    def change_focus (
         self,
-        *,
-        focus="",
-        bias=1,
-        limit_phrases: int = 10,
-        limit_sentences: int = 4,
-        preserve_order: bool = False,
-        ) -> typing.Iterator[str]:
+        focus: str = None,
+        bias: float = _NODE_BIAS
+        ) -> typing.List[Phrase]:
         """
-Run an
-[*extractive summarization*](https://derwen.ai/docs/ptr/glossary/#extractive-summarization),
-based on the vector distance (per sentence) for each of the top-ranked phrases.
+Re-runs the *Biased TextRank* algorithm with the given focus.
+This approach allows an applicatino to "change focus" without
+re-running the entire pipeline.
 
-    limit_phrases:
-maximum number of top-ranked phrases to use in the distance vectors
+    focus:
+optional text (string) with space-delimited tokens to use for the *focus set*; defaults to `None`
 
-    limit_sentences:
-total number of sentences to yield for the extractive summarization
+    bias:
+optional bias for *node weight* values on tokens found within the *focus set*; defaults to `1.0`
 
-    preserve_order:
-flag to preserve the order of sentences as they originally occurred in the source text; defaults to `False`
-
-    yields:
-texts for sentences, in order
+    returns:
+list of ranked phrases, in descending order
         """
-        # calculate textrank
-        self.calc_textrank(focus, bias)
+        # update the focus parameters
+        if focus:
+            self.focus_tokens = set(focus.lower().split(" "))
+        else:
+            self.focus_tokens = set()
 
-        # build a list of sentence indices sorted by distance
-        sent_dist: typing.List[Sentence] = self.calc_sent_dist(limit_phrases)
+        self.node_bias = bias
 
-        top_sent_ids: typing.List[int] = [
-            sent.sent_id
-            for sent in sorted(sent_dist, key=lambda sent: sent.distance)
-            ]
-
-        # truncated to the specified limit
-        limit = min(limit_sentences, len(top_sent_ids))
-        top_sent_ids = top_sent_ids[:limit]
-
-        # optional: sort in ascending order of index to preserve the
-        # order in which sentences appear in the original text
-        if preserve_order:
-            top_sent_ids.sort()
-
-        # extract sentences with the least distance, up to the limit
-        # requested
-        for sent_id in top_sent_ids:
-            yield sent_dist[sent_id].text(self.doc)
+        # update the textrank phrase extraction
+        return self.calc_textrank()

--- a/pytextrank/positionrank.py
+++ b/pytextrank/positionrank.py
@@ -106,12 +106,12 @@ Biased restart probabilities to use in the *PageRank* algorithm.
             for k, w in accumulated_weighted_tokens
         }
 
-        weighted_nodes = {
-            # while the authors assign higher probability to a "word",
-            # our *lemma graph* vertices are (lemma, pos) tuples,
-            # therefore we map each `Lemma` weight to all the *lemma
-            # graph* vertices which contain it
-            # TODO: should this map to (lemma, pos) pairs instead?
+        # while the authors assign higher probability to a "word",
+        # our *lemma graph* vertices are (lemma, pos) tuples,
+        # therefore we map each `Lemma` weight to all the *lemma
+        # graph* vertices which contain it
+        # TODO: should this map to (lemma, pos) pairs instead?
+        weighted_nodes: typing.Dict[Lemma, float] = {
             Lemma(token.lemma_, token.pos_): norm_weighted_tokens[token.lemma_]
             for token in self.doc
             if token.pos_ in self.pos_kept

--- a/sample.py
+++ b/sample.py
@@ -83,3 +83,29 @@ tr.write_dot(path="lemma_graph.dot")
 # yielding its top 5 sentences...
 for sent in tr.summary(limit_phrases=15, limit_sentences=5):
     ic(sent)
+
+print("\n----\n")
+
+nlp = spacy.load("en_core_web_sm")
+nlp.add_pipe("biasedtextrank")
+
+with open("dat/lee.txt", "r") as f:
+    text = f.read()
+doc = nlp(text)
+
+tr = doc._.textrank
+
+phrases = tr.get_phrases()
+
+for phrase in phrases[:20]:
+    ic(phrase)
+
+print("\n----\n")
+
+phrases = tr.get_phrases(focus="It wasn't until the following year that Deep Blue topped Kasparov over the course of a six-game contest.", bias=10)
+
+for phrase in phrases[:20]:
+    ic(phrase)
+
+print("\n----\n")
+

--- a/sample.py
+++ b/sample.py
@@ -19,9 +19,7 @@ nlp = spacy.load("en_core_web_sm")
 nlp.add_pipe("textrank")
 
 # parse the document
-with open("dat/mih.txt", "r") as f:
-    text = f.read()
-
+text = pathlib.Path("dat/mih.txt").read_text()
 doc = nlp(text)
 
 ## access the TextRank component, for post-processing
@@ -41,9 +39,7 @@ for phrase in doc._.phrases:
 print("\n----\n")
 
 # switch to a longer text document...
-with open("dat/lee.txt", "r") as f:
-    text = f.read()
-
+text = pathlib.Path("dat/lee.txt").read_text()
 doc = nlp(text)
 
 for phrase in doc._.phrases[:20]:
@@ -52,9 +48,7 @@ for phrase in doc._.phrases[:20]:
 print("\n----\n")
 
 # to show use of stopwords: first we output a baseline...
-with open("dat/gen.txt", "r") as f:
-    text = f.read()
-
+text = pathlib.Path("dat/gen.txt").read_text()
 doc = nlp(text)
 
 for phrase in doc._.phrases[:10]:
@@ -86,26 +80,34 @@ for sent in tr.summary(limit_phrases=15, limit_sentences=5):
 
 print("\n----\n")
 
+# show use of Biased TextRank algorithm
+EXPECTED_PHRASES = [
+    "grandmaster Lee Sedol",
+    "Lee Sedol",
+    "more international titles",
+    "world chess champion Gary Kasparov",
+    "Deep Blue",
+    "Gary Kasparov",
+    "Wednesday afternoon",
+]
+
 nlp = spacy.load("en_core_web_sm")
 nlp.add_pipe("biasedtextrank")
 
-with open("dat/lee.txt", "r") as f:
-    text = f.read()
+text = pathlib.Path("dat/lee.txt").read_text()
 doc = nlp(text)
 
+for phrase in doc._.phrases[:len(EXPECTED_PHRASES)]:
+    ic(phrase)
+
+print("\n----\n")
 tr = doc._.textrank
 
-phrases = tr.get_phrases()
+phrases = tr.change_focus(
+    focus="It wasn't until the following year that Deep Blue topped Kasparov over the course of a six-game contest.",
+    bias=10.0,
+    )
 
-for phrase in phrases[:20]:
-    ic(phrase)
-
-print("\n----\n")
-
-phrases = tr.get_phrases(focus="It wasn't until the following year that Deep Blue topped Kasparov over the course of a six-game contest.", bias=10)
-
-for phrase in phrases[:20]:
-    ic(phrase)
-
-print("\n----\n")
-
+for phrase in phrases[:len(EXPECTED_PHRASES)]:
+    ic(phrase.text)
+    assert phrase.text in EXPECTED_PHRASES


### PR DESCRIPTION
Hey @ceteri 
I have added basic version of biased textrank.

It takes into account "focus" as well "bias" to augment ranking in favour of focus.
As per the [paper](https://arxiv.org/abs/2011.01026), it should add bias to the graph based on similarity calculation between "focus" and nodes. 
But this version just assigns "bias" to focus terms while leaving other nodes unbiased.

Let me know of your ideas so that we can improve upon this version.

@louisguitton 