### PR TITLE
Add default bias parameter to change_focus function.

### DIFF
--- a/pytextrank/base.py
+++ b/pytextrank/base.py
@@ -284,6 +284,7 @@ optional dictionary of `lemma: [pos]` items to define the *stop words*, where ea
         # internal data for BiasedTextRank
         self.focus_tokens: typing.Set[str] = set()
         self.node_bias = 1.0
+        self.default_bias = 1.0
 
         # effectively, performs the same work as the `reset()` method;
         # called explicitly here for the sake of type annotations

--- a/pytextrank/biasedrank.py
+++ b/pytextrank/biasedrank.py
@@ -77,7 +77,7 @@ bias to apply for the *node weight*
         if token.lemma_ in self.focus_tokens:
             return self.node_bias
 
-        return self._DEFAULT_BIAS
+        return self.default_bias
 
 
     def get_personalization (
@@ -117,7 +117,8 @@ biased restart probabilities to use in the *PageRank* algorithm.
     def change_focus (
         self,
         focus: str = None,
-        bias: float = _DEFAULT_BIAS
+        bias: float = _DEFAULT_BIAS,
+        default_bias= _DEFAULT_BIAS
         ) -> typing.List[Phrase]:
         """
 Re-runs the *Biased TextRank* algorithm with the given focus.
@@ -130,6 +131,9 @@ optional text (string) with space-delimited tokens to use for the *focus set*; d
     bias:
 optional bias for *node weight* values on tokens found within the *focus set*; defaults to `1.0`
 
+    default_bias:
+optional bias for *node weight* values on tokens not found within the *focus set*; defaults to `1.0`
+
     returns:
 list of ranked phrases, in descending order
         """
@@ -140,6 +144,7 @@ list of ranked phrases, in descending order
             self.focus_tokens = set()
 
         self.node_bias = bias
+        self.default_bias = default_bias
 
         # update the textrank phrase extraction
         self.doc._.phrases = self.calc_textrank()

--- a/pytextrank/biasedrank.py
+++ b/pytextrank/biasedrank.py
@@ -54,7 +54,7 @@ This class does not get called directly; instantiate its factory
 instead.
     """
 
-    _NODE_BIAS: float = 1.0
+    _DEFAULT_BIAS: float = 1.0
 
 
     def _get_node_bias (
@@ -77,7 +77,7 @@ bias to apply for the *node weight*
         if token.lemma_ in self.focus_tokens:
             return self.node_bias
 
-        return self._NODE_BIAS
+        return self._DEFAULT_BIAS
 
 
     def get_personalization (
@@ -117,7 +117,7 @@ biased restart probabilities to use in the *PageRank* algorithm.
     def change_focus (
         self,
         focus: str = None,
-        bias: float = _NODE_BIAS
+        bias: float = _DEFAULT_BIAS
         ) -> typing.List[Phrase]:
         """
 Re-runs the *Biased TextRank* algorithm with the given focus.

--- a/sample.py
+++ b/sample.py
@@ -84,11 +84,11 @@ print("\n----\n")
 EXPECTED_PHRASES = [
     "grandmaster Lee Sedol",
     "Lee Sedol",
-    "more international titles",
-    "world chess champion Gary Kasparov",
     "Deep Blue",
+    "world chess champion Gary Kasparov",
     "Gary Kasparov",
-    "Wednesday afternoon",
+    "the following year",
+    "Kasparov",
 ]
 
 nlp = spacy.load("en_core_web_sm")
@@ -106,6 +106,7 @@ tr = doc._.textrank
 phrases = tr.change_focus(
     focus="It wasn't until the following year that Deep Blue topped Kasparov over the course of a six-game contest.",
     bias=10.0,
+    default_bias=0.0
     )
 
 for phrase in phrases[:len(EXPECTED_PHRASES)]:


### PR DESCRIPTION
@ceteri 

I did some testing for long documents(full text research papers) and found that just adding bias to focus does not necessarily change the rank list in favour of focus. Reason being, that upon normalisation focus bias gets competition from the collective sum of the bias assigned to non focus nodes(in our case 1). 
 Now of course user can provide a very high bias (>100) and achieve the desired result but that way we are forcing user to consider the size of the whole document and then decide on an appropriate `node_bias `that will be sufficient to rig the election in favour of focus nodes.
 
I thing if we give user an option to decide upon the `default_bias` also we can liberate him from this calculation.
Once we assign 0 bias to non focus nodes it"s becomes easier for focus nodes to perform coup d'état without taking into consideration the number of non focus nodes there are to compete with.  :)

Let me know of your thoughts on this.
 