### PR TITLE
Remove no-commit-to-branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,6 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
     -   id: detect-private-key
-    -   id: no-commit-to-branch
-        args: ["--branch", "main"]
 -   repo: https://github.com/PyCQA/bandit
     rev: 1.7.0
     hooks:


### PR DESCRIPTION
The pre-commit config has one check `no-commit-to-branch` (https://github.com/pre-commit/pre-commit-hooks#no-commit-to-branch) that currently breaks the CI when it runs on `main`. 
In this PR we remove this check because:

- we want CI  (pre-commit and pytest) to run both on PRs and against `main` (in case changes were added without a PR)
- this check currently protects against cases that cannot happen because external contributors have to fork the repo anyway

The alternative would be to change `.github/workflows/ci.yml` like so
```diff
- on: [push, pull_request, workflow_dispatch]
+ on: [pull_request, workflow_dispatch]
```
But this wouldn't allow you to show to users that CI passes on latest main branch
For example with:
```md
![CI](https://github.com/DerwenAI/pytextrank/workflows/ci/badge.svg)
```