### PR TITLE
Improved test suite; fixed tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,27 +19,85 @@ Language shared fixture.
     return nlp
 
 
+def get_doc (nlp: Language, file_path: str) -> Doc:  # pylint: disable=W0621
+    """
+Doc shared fixture.
+
+    file_path:
+String specifying the path to the doc of interest.
+
+    returns:
+spaCy EN doc containing the data from ``file_path``.
+    """
+    text = pathlib.Path(file_path).read_text()
+    doc = nlp(text)  # pylint: disable=W0621
+    return doc
+
+
 @pytest.fixture(scope="session")
-def doc (nlp: Language) -> Doc:  # pylint: disable=W0621
+def doc_ars (nlp: Language) -> Doc:  # pylint: disable=W0621
+    """
+Doc shared fixture.
+
+    returns:
+spaCy EN doc containing a piece of weather research.
+    """
+    return get_doc(nlp, "dat/ars.txt")
+
+
+@pytest.fixture(scope="session")
+def doc_cfc (nlp: Language) -> Doc:  # pylint: disable=W0621
     """
 Doc shared fixture.
 
     returns:
 spaCy EN doc containing a piece of football news.
     """
-    text = pathlib.Path("dat/cfc.txt").read_text()
-    doc = nlp(text)  # pylint: disable=W0621
-    return doc
+    return get_doc(nlp, "dat/cfc.txt")
 
 
 @pytest.fixture(scope="session")
-def long_doc (nlp: Language) -> Doc:  # pylint: disable=W0621
+def doc_gen (nlp: Language) -> Doc:  # pylint: disable=W0621
     """
 Doc shared fixture.
 
     returns:
-spaCy EN doc containing a long text.
+spaCy EN doc containing a bit of information on TextRank.
     """
-    text = pathlib.Path("dat/lee.txt").read_text()
-    doc = nlp(text)  # pylint: disable=W0621
-    return doc
+    return get_doc(nlp, "dat/gen.txt")
+
+
+@pytest.fixture(scope="session")
+def doc_lee (nlp: Language) -> Doc:  # pylint: disable=W0621
+    """
+Doc shared fixture.
+
+    returns:
+spaCy EN doc containing a bit of news on Google's AlphaGo AI.
+    """
+    return get_doc(nlp, "dat/lee.txt")
+
+
+@pytest.fixture(scope="session")
+def doc_mih (nlp: Language) -> Doc:  # pylint: disable=W0621
+    """
+Doc shared fixture.
+
+    returns:
+spaCy EN doc containing a bit of math text.
+    """
+    return get_doc(nlp, "dat/mih.txt")
+
+
+@pytest.fixture(scope="session")
+def doc_suz (nlp: Language) -> Doc:  # pylint: disable=W0621
+    """
+Doc shared fixture.
+
+    returns:
+spaCy EN doc containing a bit of text with chemistry terms.
+    """
+    return get_doc(nlp, "dat/suz.txt")
+
+doc = doc_cfc
+long_doc = doc_lee

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -81,7 +81,7 @@ and more.
         assert len(doc._.phrases) == 0
 
 
-def test_summary (nlp: Language):
+def test_summary (long_doc: Doc):
     """
 Summarization produces the expected results.
 Limit evaluation to Top-K
@@ -90,57 +90,43 @@ Limit evaluation to Top-K
     LIMIT_PHRASES = 10
     TOP_K = 5
 
+    # expected for spacy==3.2.1 and en-core-web-sm==3.2.0
     expected_trace = [
-        [0, [0, 9, 2, 6]],
-        [1, [9]],
-        [2, [2]],
-        [3, [7]],
-        [4, [8]],
+        [0, {0, 1, 6, 8, 9}],
+        [1, {9}],
+        [2, {1}],
+        [3, {7}],
+        [6, {9, 4}],
     ]
 
-    with open("dat/lee.txt", "r") as f:
-        text = f.read()
-        doc = nlp(text)
-        tr = doc._.textrank
+    tr = long_doc._.textrank
 
-        # calculates *unit vector* and sentence distance measures
-        # when
-        trace = [
-            [ sent_dist.sent_id, list(sent_dist.phrases) ]
-            for sent_dist in tr.calc_sent_dist(limit_phrases=LIMIT_PHRASES)
-            if not sent_dist.empty()
-            ]
+    # calculates *unit vector* and sentence distance measures
+    # when
+    trace = [
+        [ sent_dist.sent_id, sent_dist.phrases ]
+        for sent_dist in tr.calc_sent_dist(limit_phrases=LIMIT_PHRASES)
+        if not sent_dist.empty()
+        ]
 
-        # then
-        assert trace[:TOP_K] == expected_trace
+    # then
+    assert trace[:TOP_K] == expected_trace
 
 
-def test_multiple_summary (nlp: Language):
+def test_multiple_summary (doc_lee: Doc, doc_mih: Doc):
     """
 Summarization produces consistent results when called across multiple
 docs.
     """
-    texts = []
-
-    with open("dat/lee.txt", "r") as f:
-        text = f.read()
-        texts.append(text)
-
-    with open("dat/mih.txt", "r") as f:
-        text = f.read()
-        texts.append(text)
-
-    docs = [nlp(text) for text in texts]
-
     trace1 = [
-        [sent_dist.sent_id, list(sent_dist.phrases)]
-        for sent_dist in docs[0]._.textrank.calc_sent_dist(limit_phrases=10)
+        [sent_dist.sent_id, sent_dist.phrases]
+        for sent_dist in doc_lee._.textrank.calc_sent_dist(limit_phrases=10)
         if not sent_dist.empty()
     ]
 
     trace2 = [
-        [sent_dist.sent_id, list(sent_dist.phrases)]
-        for sent_dist in docs[1]._.textrank.calc_sent_dist(limit_phrases=10)
+        [sent_dist.sent_id, sent_dist.phrases]
+        for sent_dist in doc_mih._.textrank.calc_sent_dist(limit_phrases=10)
         if not sent_dist.empty()
     ]
 
@@ -213,13 +199,11 @@ Works as a pipeline component and can be disabled.
 
         return scrubber_func
 
-
     # add "articles_scrubber" to config
     # then see if phrases have `articles` in it?
 
     nlp2 = spacy.load("en_core_web_sm")
     nlp2.add_pipe("textrank", config={"stopwords": {"test": ["NOUN"]}, "scrubber": {"@misc": "articles_scrubber"}}, last=True)
-
 
     # then
     doc = nlp2(text)

--- a/tests/test_positionrank.py
+++ b/tests/test_positionrank.py
@@ -39,5 +39,5 @@ does.
 
     assert "Chelsea" in [p.text for p in phrases[:10]]
     assert "Chelsea" not in [p.text for p in comparison_phrases[:10]]
-    assert "Shanghai Shenhua" not in [p.text for p in phrases[:10]]
-    assert "Shanghai Shenhua" in [p.text for p in comparison_phrases[:10]]
+    assert "Shanghai Shenhua" not in ";".join(p.text for p in phrases[:10])
+    assert "Shanghai Shenhua" in ";".join(p.text for p in comparison_phrases[:10])


### PR DESCRIPTION
Hello!

## Pull request overview
* Improved test suite: created easily accessible fixtures per document in `conftest.py`.
* Fixed tests for `spacy==3.2.1` and `en-core-web-sm==3.2.0`.

## Details
#### `conftest.py` changes
First and foremost you'll see many changes in `conftest.py`. I've included fixtures for each of the individual documents, so they can be more easily used throughout the test suite from now on. Note that `doc` and `long_doc` still exist, and this update is exclusively *additions* rather than *changes*.

#### `test_base.py` changes
The main changes here are within the `test_summary` function. Firstly, I've started using the `long_doc` fixture here, so the function itself doesn't need to worry about filepaths to data files etc. Beyond that, I've updated the expected results for `spacy==3.2.1` and `en-core-web-sm==3.2.0`. Because we rely so heavily on spaCy, we'll always run into situations where tests break, but at least now there is a comment specifying for which versions these tests pass. Lastly, I've stopped converting the `sent_dist.phrases` set to a list, as I see no need to do that. Set order is (mathematically) undefined, and so I'd rather not rely on Python to ensure ordering.

Then, I've also added my new fixtures to `test_multiple_summary`.

#### `test_positionrank.py` changes
This fix is a little bit of a hack, but works well for now. In essence, the issue here was that we expect `'Shanghai Shenhua'` to exist in one of the lists, but not in the other. However, with recent spaCy model changes, only `'Shanghai Shenhua striker Odion Ighalo'` appears in the list. This causes a test failure, despite the chunk with `'Shanghai Shenhua'` being ranked number 1 like expected. 

The hack is simply to convert the list of strings into one long string, and check whether `'Shanghai Shenhua'` is or is not a substring of this long list. This means that it will also check whether `'Shanghai Shenhua'` is a substring of one of the chunks, which seems to be what we want.

---

On a more general note, it might be prudent to have a central place where the specific versions of spaCy and its models are listed, so it becomes a bit easier to update the tests in the future. (Apologies if this already exists, and I couldn't find it)

Let me know if there are issues or comments - I'm always open to feedback.

- Tom Aarsen