### PR TITLE
Inclusion of the TopicRank Keyphrase Extraction algorithm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,28 @@ name: CI
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  lint-and-test:
+  pre-commit:
+    name: Run pre-commit
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10]
+    needs: pre-commit
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -19,7 +32,6 @@ jobs:
           spacy download en_core_web_sm
           pip install pre-commit pytest
 
-      - uses: pre-commit/action@v2.0.2
       - name: Run tests
         run: |
           pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: pre-commit/action@v2.0.0
 
   test:
-    name: Tests for Python ${{ matrix.python-version }
+    name: Tests for Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     needs: pre-commit
+    fail-fast: false
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
+      fail-fast: false
     needs: pre-commit
-    fail-fast: false
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: pre-commit/action@v2.0.0
 
   test:
+    name: Tests for Python ${{ matrix.python-version }
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/pytextrank/__init__.py
+++ b/pytextrank/__init__.py
@@ -10,6 +10,7 @@ from spacy.language import Language  # type: ignore # pylint: disable=E0401
 from .base import BaseTextRankFactory, BaseTextRank, Lemma, Paragraph, Phrase, Sentence, VectorElem, StopWordsLike
 from .biasedrank import BiasedTextRankFactory, BiasedTextRank
 from .positionrank import PositionRankFactory, PositionRank
+from .topicrank import TopicRankFactory, TopicRank
 from .util import groupby_apply, default_scrubber, maniacal_scrubber, split_grafs, filter_quotes
 from .version import MIN_PY_VERSION, _versify, _check_version, __version__
 
@@ -23,6 +24,12 @@ _DEFAULT_CONFIG = {
     "token_lookback": BaseTextRankFactory._TOKEN_LOOKBACK,  # pylint: disable=W0212
     "scrubber": None,
     "stopwords": None,
+    }
+
+_TOPIC_DEFAULT_CONFIG = {
+    **_DEFAULT_CONFIG,
+    "threshold": TopicRankFactory._CLUSTER_THRESHOLD,  # pylint: disable=W0212
+    "method": TopicRankFactory._CLUSTER_METHOD,  # pylint: disable=W0212
     }
 
 
@@ -93,6 +100,32 @@ Component factory for the `BiasedTextRank` extended class.
             token_lookback = token_lookback,
             scrubber = scrubber,
             stopwords = stopwords,
+        )
+
+
+    @Language.factory("topicrank", default_config=_TOPIC_DEFAULT_CONFIG)
+    def _create_component_tor (
+        nlp: Language,  # pylint: disable=W0613
+        name: str,  # pylint: disable=W0613
+        edge_weight: float,
+        pos_kept: typing.List[str],
+        token_lookback: int,
+        scrubber: typing.Optional[typing.Callable],
+        stopwords: typing.Optional[StopWordsLike],
+        threshold: float,
+        method: str,
+        ) -> TopicRankFactory:
+        """
+Component factory for the `TopicRank` extended class.
+        """
+        return TopicRankFactory(
+            edge_weight = edge_weight,
+            pos_kept = pos_kept,
+            token_lookback = token_lookback,
+            scrubber = scrubber,
+            stopwords = stopwords,
+            threshold = threshold,
+            method = method,
         )
 
 except Exception:  # pylint: disable=W0703

--- a/pytextrank/topicrank.py
+++ b/pytextrank/topicrank.py
@@ -198,6 +198,8 @@ list of clusters of candidates.
         # using a threshold of 0.01 below 1 - threshold.
         # So, 0.74 for the default 0.25 threshold.
         pairwise_dist = pdist(matrix, "jaccard")
+        if not pairwise_dist.size:
+            return [[candidate] for candidate in candidates]
         raw_clusters = linkage(pairwise_dist, method=self.method)
         cluster_ids = fcluster(
             raw_clusters, t=0.99 - self.threshold, criterion="distance"

--- a/pytextrank/topicrank.py
+++ b/pytextrank/topicrank.py
@@ -234,7 +234,7 @@ list of candidate spans
         return candidates
 
     @property  # type: ignore
-    @lru_cache
+    @lru_cache(maxsize=1)
     def node_list(self) -> typing.List[typing.Tuple[Span, ...]]:  # type: ignore
         """
 Build a list of vertices for the graph, cached for efficiency.

--- a/pytextrank/topicrank.py
+++ b/pytextrank/topicrank.py
@@ -316,15 +316,18 @@ list of ranked phrases, in descending order
         # the number candidate keyphrases that make up the topic.
         raw_phrase_list = [
             Phrase(
-                text=min(
-                    ((chunk.text, chunk.start) for chunk in chunks),
-                    key=lambda tup: tup[1],
-                )[0],
-                chunks=list(chunks),
-                count=len(chunks),
+                text=self.scrubber(
+                    # get first occurring keyphrase for topic
+                    min(
+                        ((keyphrase, keyphrase.start) for keyphrase in topic),
+                        key=lambda tup: tup[1],
+                    )[0]
+                ),
+                chunks=list(topic),
+                count=len(topic),
                 rank=score,
             )
-            for chunks, score in self.ranks.items()
+            for topic, score in self.ranks.items()
         ]
         phrase_list: typing.List[Phrase] = sorted(
             raw_phrase_list, key=lambda p: p.rank, reverse=True

--- a/pytextrank/topicrank.py
+++ b/pytextrank/topicrank.py
@@ -11,10 +11,10 @@ import typing
 from collections import defaultdict
 from functools import lru_cache
 
-import networkx as nx
-from scipy.cluster.hierarchy import fcluster, linkage
-from scipy.spatial.distance import pdist
-from spacy.tokens import Doc, Span
+import networkx as nx  # type: ignore # pylint: disable=E0401
+from scipy.cluster.hierarchy import fcluster, linkage  # type: ignore # pylint: disable=E0401
+from scipy.spatial.distance import pdist  # type: ignore # pylint: disable=E0401
+from spacy.tokens import Doc, Span  # type: ignore # pylint: disable=E0401
 
 from .base import BaseTextRank, BaseTextRankFactory, Phrase, StopWordsLike
 
@@ -211,7 +211,7 @@ list of clusters of candidates.
         for cluster_id, candidate in zip(cluster_ids, candidates):
             clusters[cluster_id].append(candidate)
 
-        return clusters.values()
+        return list(clusters.values())
 
     def _get_candidates(self) -> typing.List[Span]:
         """
@@ -233,9 +233,9 @@ list of candidate spans
 
         return candidates
 
-    @property
+    @property  # type: ignore
     @lru_cache
-    def node_list(self) -> typing.List[typing.List[Span]]:
+    def node_list(self) -> typing.List[typing.Tuple[Span, ...]]:  # type: ignore
         """
 Build a list of vertices for the graph, cached for efficiency.
 
@@ -256,7 +256,7 @@ list of nodes
         return clustered
 
     @property
-    def edge_list(
+    def edge_list(  # type: ignore
         self,
     ) -> typing.List[
         typing.Tuple[typing.List[Span], typing.List[Span], typing.Dict[str, float]]
@@ -269,8 +269,8 @@ list of weighted edges
         """
 
         weighted_edges = []
-        for i, source_topic in enumerate(self.node_list):
-            for target_topic in self.node_list[i + 1 :]:
+        for i, source_topic in enumerate(self.node_list):  # type: ignore
+            for target_topic in self.node_list[i + 1 :]:  # type: ignore
                 weight = 0.0
                 for source_member in source_topic:
                     for target_member in target_topic:
@@ -303,7 +303,7 @@ list of ranked phrases, in descending order
         # to run the algorithm, we use the NetworkX implementation
         # for PageRank (i.e., based on eigenvector centrality)
         # to calculate a rank for each node in the lemma graph
-        self.ranks: typing.Dict[typing.List[Span], float] = nx.pagerank(
+        self.ranks: typing.Dict[typing.List[Span], float] = nx.pagerank(  # type: ignore
             self.lemma_graph,
             personalization=self.get_personalization(),
         )
@@ -344,4 +344,4 @@ Reinitialize the data structures needed for extracting phrases,
 removing any pre-existing state.
         """
         super().reset()
-        TopicRank.node_list.fget.cache_clear()
+        TopicRank.node_list.fget.cache_clear()  # type: ignore # pylint: disable=E1101

--- a/pytextrank/topicrank.py
+++ b/pytextrank/topicrank.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# see license https://github.com/DerwenAI/pytextrank#license-and-copyright
+
+"""
+Implements the *TopicRank* algorithm.
+"""
+
+import time
+import typing
+from collections import defaultdict
+from functools import lru_cache
+
+import networkx as nx
+from scipy.cluster.hierarchy import fcluster, linkage
+from scipy.spatial.distance import pdist
+from spacy.tokens import Doc, Span
+
+from .base import BaseTextRank, BaseTextRankFactory, Phrase, StopWordsLike
+
+
+class TopicRankFactory (BaseTextRankFactory):
+    """
+A factory class that provides the document with its instance of
+`TopicRank`
+    """
+
+    _CLUSTER_THRESHOLD: float = 0.25
+    _CLUSTER_METHOD: str = "average"
+
+    def __init__(
+        self,
+        *,
+        edge_weight: float = BaseTextRankFactory._EDGE_WEIGHT,
+        pos_kept: typing.List[str] = None,
+        token_lookback: int = BaseTextRankFactory._TOKEN_LOOKBACK,
+        scrubber: typing.Optional[typing.Callable] = None,
+        stopwords: typing.Optional[StopWordsLike] = None,
+        threshold: float = _CLUSTER_THRESHOLD,
+        method: str = _CLUSTER_METHOD
+    ) -> None:
+        super().__init__(
+            edge_weight=edge_weight,
+            pos_kept=pos_kept,
+            token_lookback=token_lookback,
+            scrubber=scrubber,
+            stopwords=stopwords,
+        )
+
+        # TopicRank clustering parameters
+        self.threshold: float = threshold
+        self.method: str = method
+
+    def __call__(
+        self,
+        doc: Doc,
+    ) -> Doc:
+        """
+Set the extension attributes on a `spaCy` [`Doc`](https://spacy.io/api/doc)
+document to create a *pipeline component* for `TopicRank` as
+a stateful component, invoked when the document gets processed.
+
+See: <https://spacy.io/usage/processing-pipelines#pipelines>
+
+    doc:
+a document container, providing the annotations produced by earlier stages of the `spaCy` pipeline
+        """
+        Doc.set_extension("textrank", force=True, default=None)
+        Doc.set_extension("phrases", force=True, default=[])
+
+        doc._.textrank = TopicRank(
+            doc,
+            edge_weight=self.edge_weight,
+            pos_kept=self.pos_kept,
+            token_lookback=self.token_lookback,
+            scrubber=self.scrubber,
+            stopwords=self.stopwords,
+            threshold=self.threshold,
+            method=self.method,
+        )
+
+        doc._.phrases = doc._.textrank.calc_textrank()
+        return doc
+
+
+class TopicRank (BaseTextRank):
+    """Implements the *TopicRank* algorithm described by
+TODO, deployed as a `spaCy` pipeline component.
+
+https://aclanthology.org/I13-1062.pdf
+
+This class does not get called directly; instantiate its factory
+instead.
+
+Algorithm Overview:
+
+1. Preprocessing: Sentence segmentation, word tokenization, POS tagging.
+   After this stage, we have preprocessed text.
+2. Candidate extraction: Extract sequences of nouns and adjectives (i.e. noun chunks)
+   After this stage, we have a list of keyphrases that may be topics.
+3. Candidate clustering: Hierarchical Agglomerative Clustering algorithm with average
+   linking using simple set-based overlap of lemmas. Similarity is achieved at > 25%
+   overlap. **Note**: PyTextRank deviates from the original algorithm here, which uses
+   stems rather than lemmas.
+   After this stage, we have a list of topics.
+4. Candidate ranking: Apply *TextRank* on a complete graph, with topics as nodes
+   (i.e. clusters derived in the last step), where edge weights are higher between
+   topics that appear closer together within the document.
+   After this stage, we have a ranked list of topics.
+5. Candidate selection: Select the first occurring keyphrase from each topic to
+   represent that topic.
+   After this stage, we have a ranked list of topics, with a keyphrase to represent
+   the topic.
+    """
+
+    def __init__(
+        self,
+        doc: Doc,
+        edge_weight: float,
+        pos_kept: typing.List[str],
+        token_lookback: int,
+        scrubber: typing.Callable,
+        stopwords: typing.Dict[str, typing.List[str]],
+        threshold: float,
+        method: str,
+    ) -> None:
+        """
+Constructor for a factory used to instantiate the PyTextRank pipeline components.
+
+    edge_weight:
+default weight for an edge
+
+    pos_kept:
+parts of speech tags to be kept; adjust this if strings representing the POS tags change
+
+    token_lookback:
+the window for neighboring tokens – similar to a *skip gram*
+
+    scrubber:
+optional "scrubber" function to clean up punctuation from a token; if `None` then defaults to `pytextrank.default_scrubber`; when running, PyTextRank will throw a `FutureWarning` warning if the configuration uses a deprecated approach for a scrubber function
+
+    stopwords:
+optional dictionary of `lemma: [pos]` items to define the *stop words*, where each item has a key as a lemmatized token and a value as a list of POS tags; may be a file name (string) or a [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html) for a JSON file; otherwise throws a `TypeError` exception
+
+    threshold:
+threshold used in *TopicRank* candidate clustering; the original algorithm uses 0.25
+
+    method:
+clustering method used in *TopicRank* candidate clustering: see [`scipy.cluster.hierarchy.linkage`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.linkage.html) for valid methods; the original algorithm uses "average"
+        """
+        super().__init__(
+            doc, edge_weight, pos_kept, token_lookback, scrubber, stopwords
+        )
+
+        # TopicRank candidate clustering parameters
+        self.threshold: float = threshold
+        self.method: str = method
+
+    def _cluster(self, candidates: typing.List[Span]) -> typing.List[typing.List[Span]]:
+        """
+Cluster candidates using Hierarchical Agglomerative Clustering (HAC),
+where similarity is defined by overlap of lemmas in candidates.
+
+The `threshold` and `method` parameters influence the clustering
+behaviour. A `threshold` of 0.25 means that there must at least be
+a 25% overlap of lemmas between two candidates for them to be allowed
+in the same cluster.
+
+    candidates:
+list of spans, where each span is a candidate topic.
+
+    returns:
+list of clusters of candidates.
+        """
+        bag_of_words = list(
+            {
+                word.text
+                for candidate in candidates
+                for word in candidate
+                if not word.is_stop
+            }
+        )
+
+        # Create a bag-of-words representation with a
+        # |candidates|x|bag_of_words| matrix
+        # matrix = [[0] * len(bag_of_words) for _ in candidates]
+        matrix = []
+        for candidate in candidates:
+            matrix.append([0] * len(bag_of_words))
+            for term in candidate:
+                if not term.is_stop:
+                    try:
+                        matrix[-1][bag_of_words.index(term.text)] += 1
+                    except IndexError:
+                        pass
+
+        # Apply average clustering on pairwise distance,
+        # using a threshold of 0.01 below 1 - threshold.
+        # So, 0.74 for the default 0.25 threshold.
+        pairwise_dist = pdist(matrix, "jaccard")
+        raw_clusters = linkage(pairwise_dist, method=self.method)
+        cluster_ids = fcluster(
+            raw_clusters, t=0.99 - self.threshold, criterion="distance"
+        )
+
+        # Map cluster_ids to the corresponding candidates, and then
+        # ignore the cluster id keys.
+        clusters = defaultdict(list)
+        for cluster_id, candidate in zip(cluster_ids, candidates):
+            clusters[cluster_id].append(candidate)
+
+        return clusters.values()
+
+    def _get_candidates(self) -> typing.List[Span]:
+        """
+Return a list of spans with candidate topics, such that the start of
+each candidate is a noun chunk that was trimmed of stopwords or tokens
+with POS tags that we wish to ignore.
+
+    returns:
+list of candidate spans
+        """
+        noun_chunks = list(self.doc.noun_chunks)
+
+        candidates = []
+        for chunk in noun_chunks:
+            for token in chunk:
+                if self._keep_token(token):
+                    candidates.append(self.doc[token.i : chunk.end])
+                    break
+
+        return candidates
+
+    @property
+    @lru_cache
+    def node_list(self) -> typing.List[typing.List[Span]]:
+        """
+Build a list of vertices for the graph, cached for efficiency.
+
+    returns:
+list of nodes
+        """
+
+        # Rely on spaCy to perform *preprocessing* and *candidate extraction*
+        # through ``noun_chunks``, thus completing the first two steps of
+        # the *TopicRank* algorithm.
+        candidates = self._get_candidates()
+
+        # Cluster candidates together using a simple set-based overlap of
+        # lemmas. Clustering can occur if the overlap is more than 25%.
+        # Map to a tuple so these clusters are hashable.
+        clustered = [tuple(cluster) for cluster in self._cluster(candidates)]
+
+        return clustered
+
+    @property
+    def edge_list(
+        self,
+    ) -> typing.List[
+        typing.Tuple[typing.List[Span], typing.List[Span], typing.Dict[str, float]]
+    ]:
+        """
+Build a list of weighted edges for the graph.
+
+    returns:
+list of weighted edges
+        """
+
+        weighted_edges = []
+        for i, source_topic in enumerate(self.node_list):
+            for target_topic in self.node_list[i + 1 :]:
+                weight = 0.0
+                for source_member in source_topic:
+                    for target_member in target_topic:
+                        distance = abs(source_member.start - target_member.start)
+                        if distance:
+                            weight += 1.0 / distance
+                weight_dict = {"weight": weight * self.edge_weight}
+                weighted_edges.append((source_topic, target_topic, weight_dict))
+                weighted_edges.append((target_topic, source_topic, weight_dict))
+
+        return weighted_edges
+
+    def calc_textrank(self) -> typing.List[Phrase]:
+        """
+Construct a complete graph using potential topics as nodes,
+then apply the *TextRank* algorithm to return the top-ranked phrases.
+
+This method represents the heart of the *TopicRank* algorithm.
+
+    returns:
+list of ranked phrases, in descending order
+        """
+        t0 = time.time()
+        self.reset()
+        # for *TopicRank*, the constructed graph is complete
+        # with topics as nodes and a distance measure between
+        # two topics as the weights for the edge between them.
+        self.lemma_graph = self._construct_graph()
+
+        # to run the algorithm, we use the NetworkX implementation
+        # for PageRank (i.e., based on eigenvector centrality)
+        # to calculate a rank for each node in the lemma graph
+        self.ranks: typing.Dict[typing.List[Span], float] = nx.pagerank(
+            self.lemma_graph,
+            personalization=self.get_personalization(),
+        )
+
+        # we convert the topics into a list of Phrases,
+        # such that the Phrase text is the first occurring
+        # candidate keyphrase of that topic.
+        # The chunks correspond to the topic clustering, the
+        # rank is simply the TextRank score, and the count is
+        # the number candidate keyphrases that make up the topic.
+        raw_phrase_list = [
+            Phrase(
+                text=min(
+                    ((chunk.text, chunk.start) for chunk in chunks),
+                    key=lambda tup: tup[1],
+                )[0],
+                chunks=list(chunks),
+                count=len(chunks),
+                rank=score,
+            )
+            for chunks, score in self.ranks.items()
+        ]
+        phrase_list: typing.List[Phrase] = sorted(
+            raw_phrase_list, key=lambda p: p.rank, reverse=True
+        )
+
+        t1 = time.time()
+        self.elapsed_time = (t1 - t0) * 1000.0
+
+        return phrase_list
+
+    def reset(self) -> None:
+        """
+Reinitialize the data structures needed for extracting phrases,
+removing any pre-existing state.
+        """
+        super().reset()
+        TopicRank.node_list.fget.cache_clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from spacy.language import Language  # pylint: disable=E0401
 from spacy.tokens import Doc  # pylint: disable=E0401
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def nlp () -> Language:
     """
 Language shared fixture.
@@ -19,7 +19,7 @@ Language shared fixture.
     return nlp
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def doc (nlp: Language) -> Doc:  # pylint: disable=W0621
     """
 Doc shared fixture.
@@ -32,7 +32,7 @@ spaCy EN doc containing a piece of football news.
     return doc
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def long_doc (nlp: Language) -> Doc:  # pylint: disable=W0621
     """
 Doc shared fixture.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -51,10 +51,10 @@ Works as a pipeline component and can be disabled.
 
     # identifies phrases not in noun chunks
     # when
-    text = """
-everything you need to know about student loan interest rates variable
-and fixed rates capitalization amortization student loan refinancing
-and more.
+    text = """\
+everything you need to know about student loan interest rates variable \
+and fixed rates capitalization amortization student loan refinancing \
+and more.\
 """
 
     doc = nlp(text)

--- a/tests/test_topicrank.py
+++ b/tests/test_topicrank.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# type: ignore
+
+"""Unit tests for BaseTextRank."""
+from spacy.language import Language  # pylint: disable=E0401
+from spacy.tokens import Span, Doc  # pylint: disable=E0401
+import spacy  # pylint: disable=E0401
+
+import sys
+sys.path.insert(0, "../pytextrank")
+
+from pytextrank.topicrank import TopicRankFactory  # pylint: disable=E0401
+
+
+def test_base_topic_rank (doc: Doc):
+    """
+Ranks unique keywords in a document correctly, sorted decreasing by
+centrality.
+    """
+    # given
+    base_text_rank = TopicRankFactory()
+
+    # when
+    processed_doc = base_text_rank(doc)
+    phrases = processed_doc._.phrases
+
+    # then
+    assert len(phrases) > 0
+    assert len(set(p.text for p in phrases)) == len(phrases)
+    assert phrases[0].rank == max(p.rank for p in phrases)
+
+def test_add_pipe (nlp: Language):
+    """
+Works as a pipeline component and can be disabled.
+    """
+    # given
+    nlp.add_pipe("topicrank", last=True)
+
+    # works as a pipeline component
+    # when
+    text = "linear constraints over the"
+    doc = nlp(text)
+    phrases = [ p.text for p in doc._.phrases ]
+
+    # then
+    assert len(doc._.phrases) > 0
+    assert any(map(lambda x: "constraints" in x, phrases))
+
+    # identifies phrases not in noun chunks
+    # when
+    text = """\
+everything you need to know about student loan interest rates, variable \
+and fixed rates, capitalization, amortization, student loan refinancing \
+and more.\
+"""
+
+    doc = nlp(text)
+    phrases = [ p.text for p in doc._.phrases ]
+
+    # then
+    assert len(doc._.phrases) >= 2
+
+    # resolves Py 3.5 dict KeyError
+    # when
+    text = "linear constraints over the set of natural numbers"
+    doc = nlp(text)
+    phrases = [ p.text for p in doc._.phrases ]
+
+    # then
+    assert any(map(lambda x: "constraints" in x, phrases))
+
+    # pipeline can be disabled
+    # when
+    with nlp.select_pipes(disable=["topicrank"]):
+        doc = nlp(text)
+
+        # then
+        assert len(doc._.phrases) == 0
+
+
+def test_summary (nlp: Language):
+    """
+Summarization produces the expected results.
+Limit evaluation to Top-K
+    """
+    # given
+    LIMIT_PHRASES = 10
+    TOP_K = 5
+
+    expected_trace = [
+        [0, [2, 7]],
+        [1, [0, 1]],
+        [2, [2]],
+        [3, [8, 7]],
+        [4, [5]]
+    ]
+
+    with open("dat/lee.txt", "r") as f:
+        text = f.read()
+        doc = nlp(text)
+        tr = doc._.textrank
+
+        # calculates *unit vector* and sentence distance measures
+        # when
+        trace = [
+            [ sent_dist.sent_id, list(sent_dist.phrases) ]
+            for sent_dist in tr.calc_sent_dist(limit_phrases=LIMIT_PHRASES)
+            if not sent_dist.empty()
+            ]
+
+        # then
+        assert trace[:TOP_K] == expected_trace
+
+
+def test_multiple_summary (nlp: Language):
+    """
+Summarization produces consistent results when called across multiple
+docs.
+    """
+    texts = []
+
+    with open("dat/lee.txt", "r") as f:
+        text = f.read()
+        texts.append(text)
+
+    with open("dat/mih.txt", "r") as f:
+        text = f.read()
+        texts.append(text)
+
+    docs = [nlp(text) for text in texts]
+
+    trace1 = [
+        [sent_dist.sent_id, list(sent_dist.phrases)]
+        for sent_dist in docs[0]._.textrank.calc_sent_dist(limit_phrases=10)
+        if not sent_dist.empty()
+    ]
+
+    trace2 = [
+        [sent_dist.sent_id, list(sent_dist.phrases)]
+        for sent_dist in docs[1]._.textrank.calc_sent_dist(limit_phrases=10)
+        if not sent_dist.empty()
+    ]
+
+    assert trace1 != trace2
+
+
+def test_stop_words ():
+    """
+Works as a pipeline component and can be disabled.
+    """
+    nlp1 = spacy.load("en_core_web_sm")
+    nlp1.add_pipe("topicrank")
+
+    # "words" is in top phrases
+    with open("dat/gen.txt", "r") as f:
+        doc = nlp1(f.read())
+
+        phrases = [
+            phrase.text
+            for phrase in doc._.phrases[:5]
+            ]
+
+        assert "words" in phrases
+
+    # add `"word": ["NOUN"]` to the *stop words*, to remove instances
+    # of `"word"` or `"words"` then see how the ranked phrases differ?
+
+    nlp2 = spacy.load("en_core_web_sm")
+    nlp2.add_pipe("topicrank", config={ "stopwords": { "word": ["NOUN"] } })
+
+    with open("dat/gen.txt", "r") as f:
+        doc = nlp2(f.read())
+
+        phrases = [
+            phrase.text
+            for phrase in doc._.phrases[:5]
+            ]
+
+        assert "words" not in phrases
+
+def test_scrubber ():
+    """
+Works as a pipeline component and can be disabled.
+    """
+    # given
+
+    text = "This is a test for scrubber."
+
+    nlp1 = spacy.load("en_core_web_sm")
+    nlp1.add_pipe("topicrank", last=True)
+
+    doc = nlp1(text)
+
+    phrases = [
+        phrase.text
+        for phrase in doc._.phrases
+    ]
+
+    assert set(phrases) == {"test", "scrubber"}
+
+    @spacy.registry.misc("modify_scrubber")
+    def modify_scrubber():  # pylint: disable=W0612
+        def scrubber_func(text_span: Span) -> str:
+            print("scrubbed_func called")
+            if text_span.text == "scrubber":
+                return "modified scrubber"
+            return text_span.text
+        return scrubber_func
+
+
+    # add "modify_scrubber" to config
+    # then see if phrases has `modified scrubber` in it?
+
+    nlp2 = spacy.load("en_core_web_sm")
+    nlp2.add_pipe("topicrank", config={"stopwords": {"test": ["NOUN"]}, "scrubber": {"@misc": "modify_scrubber"}}, last=True)
+
+    # then
+    doc = nlp2(text)
+
+    phrases = [
+        phrase.text
+        for phrase in doc._.phrases
+    ]
+
+    # we expect the "test" to be filtered away (due to stopwords),
+    # and "scrubber" to be replaced with "modified scrubber"
+    assert set(phrases) == {"modified scrubber"}


### PR DESCRIPTION
Hello!
As promised: a beefier PR.

## Pull request overview
* Added an implementation of the TopicRank algorithm, including a `TopicRank` and `TopicRankFactory` class.
* Added tests for TopicRank
* Modified CI tests to run for Python 3.7 through 3.10, rather than just Python 3.7

## Details on TopicRank
TopicRank was mentioned in the useful discussion in #174 by @BrandonKMLee and @louisguitton, and was originally introduced in a paper by [(Bougouin et al., 2013)](https://aclanthology.org/I13-1062.pdf). It focuses on keyphrase extraction, and relies on TextRank as a part of the overall algorithm. The paper is quite interesting, so I would recommend looking at it, but I'll quickly summarize the algorithm that is presented (copied from my comment in the code):
1. **Preprocessing**: Sentence segmentation, word tokenization, POS tagging.
   After this stage, we have preprocessed text.
2. **Candidate extraction**: Extract sequences of nouns and adjectives (i.e. noun chunks)
   After this stage, we have a list of keyphrases that may be topics.
3. **Candidate clustering**: Hierarchical Agglomerative Clustering algorithm with average
   linking using simple set-based overlap of lemmas. Similarity is achieved at > 25%
   overlap. **Note**: PyTextRank deviates from the original algorithm here, which uses
   stems rather than lemmas.
   After this stage, we have a list of topics.
4. **Candidate ranking**: Apply *TextRank* on a complete graph, with topics as nodes
   (i.e. clusters derived in the last step), where edge weights are higher between
   topics that appear closer together within the document.
   After this stage, we have a ranked list of topics.
5. **Candidate selection**: Select the first occurring keyphrase from each topic to
   represent that topic.
   After this stage, we have a ranked list of topics, with a keyphrase to represent
   the topic.

## Sample usage & output
The `TopicRank` algorithm implemented in this PR can be used in essentially the same way as TextRank:
```python
import spacy
import pytextrank
from pprint import pprint

# Example text
text = "A mathematical model of ion exchange is considered, allowing for ion exchanger compression in the process of ion exchange. Two inverse problems are investigated for this model, unique solvability is proved, and numerical solution methods are proposed. The efficiency of the proposed methods is demonstrated by a numerical experiment."

# load a spaCy model, depending on language, scale, etc.
nlp = spacy.load("en_core_web_sm")

# add PyTextRank to the spaCy pipeline
nlp.add_pipe("topicrank")
doc = nlp(text)

# examine the top-ranked phrases in the document
pprint(doc._.phrases)
print([phrase.text for phrase in doc._.phrases][:10])
tr = doc._.textrank
print(tr.elapsed_time)
```
This outputs:
```python
[Phrase(text='ion exchange', chunks=[ion exchange, ion, ion exchange], count=3, rank=0.2164760626537704),
 Phrase(text='mathematical model', chunks=[mathematical model, model], count=2, rank=0.13294553955872498),
 Phrase(text='exchanger compression', chunks=[exchanger compression], count=1, rank=0.11752875572953524),
 Phrase(text='process', chunks=[process], count=1, rank=0.0976304878191955),
 Phrase(text='unique solvability', chunks=[unique solvability], count=1, rank=0.08867195618809895),
 Phrase(text='inverse problems', chunks=[inverse problems], count=1, rank=0.07980296596112096),
 Phrase(text='efficiency', chunks=[efficiency], count=1, rank=0.07445298452109365),
 Phrase(text='proposed methods', chunks=[proposed methods], count=1, rank=0.07279118674022787),
 Phrase(text='numerical solution methods', chunks=[numerical solution methods], count=1, rank=0.06825226658665143),
 Phrase(text='numerical experiment', chunks=[numerical experiment], count=1, rank=0.05144779424158112)]
['ion exchange', 'mathematical model', 'exchanger compression', 'process', 'unique solvability', 'inverse problems', 'efficiency', 'proposed methods', 'numerical solution methods', 'numerical experiment']
2.8972625732421875
```

To compare, this is the output of the original https://github.com/adrien-bougouin/KeyBench/ repository is as follows, when given the same input:
```
(u'ion exchange', 1.6957436822957042)
(u'mathematical model', 1.32419391897424)
(u'numerical solution methods', 1.1483448063357846)
(u'process', 0.9181346427759802)
(u'unique solvability', 0.8265677195114645)
(u'inverse problems', 0.7989594740490582)
(u'efficiency', 0.7225318465443265)
(u'numerical experiment', 0.5631577922037418)
```
This output is also given by `pke`, by the same author:
```
['ion exchange', 'mathematical model', 'numerical solution methods', 'process', 'unique solvability', 'inverse problems', 'efficiency', 'numerical experiment']
```

Full transparancy: As you can see, there are some small differences between this TopicRank implementation and the originals. E.g. `numerical solution methods` ranks lower, and `exchanger compression` ranks higher. I can try to invest a bit more time to try and debug this, but I suspect that this is caused by a differint way to find potential candidates and differing TextRank parameters. 

Lastly, for context, replacing `nlp.add_pipe("topicrank")` with `nlp.add_pipe("textrank")` gives the following results:
```
[Phrase(text='ion exchange', chunks=[ion exchange, ion exchange], count=2, rank=0.2217093467665982),
 Phrase(text='numerical solution methods', chunks=[numerical solution methods], count=1, rank=0.18495219543002075),
 Phrase(text='ion', chunks=[ion], count=1, rank=0.18185672562374786),
 Phrase(text='exchanger compression', chunks=[exchanger compression], count=1, rank=0.16266971703534683),
 Phrase(text='unique solvability', chunks=[unique solvability], count=1, rank=0.0960861890678228),
 Phrase(text='a numerical experiment', chunks=[a numerical experiment], count=1, rank=0.0916401771972592),
 Phrase(text='the proposed methods', chunks=[the proposed methods], count=1, rank=0.08875872150025549),
 Phrase(text='the process', chunks=[the process], count=1, rank=0.05602421471187259),
 Phrase(text='A mathematical model', chunks=[A mathematical model], count=1, rank=0.04383340352811856),
 Phrase(text='Two inverse problems', chunks=[Two inverse problems], count=1, rank=0.03593743181662447),
 Phrase(text='this model', chunks=[this model], count=1, rank=0.03401330317595105),
 Phrase(text='The efficiency', chunks=[The efficiency], count=1, rank=0.021969568492358083),
 Phrase(text='Two', chunks=[Two], count=1, rank=0.0)]
['ion exchange', 'numerical solution methods', 'ion', 'exchanger compression', 'unique solvability', 'a numerical experiment', 'the proposed methods', 'the process', 'A mathematical model', 'Two inverse problems']
3.9992332458496094
```

## Implementation details
### New default config
`pytextrank/__init__.py` has been given a new configuration dict: `_TOPIC_DEFAULT_CONFIG`. This configuration dict is simply an extension of the existing `_DEFAULT_CONFIG`, with the `threshold` and `method` attributes added. In this file, a component factory for the `TopicRank` class is added.

### New classes
Both a `TopicRankFactory` and `TopicRank` class were implemented, following the design structure of the previously created classes and factories, with the addition of the aforementioned `threshold` and `method` attributes.

### New attributes
The `threshold` attribute is a float between 0 and 1, which is used in the TopicRank candidate clustering algorithm to specify the minimum similarity between two keyphrases, for them to be eligible for clustering. The original paper uses a value of 0.25 (i.e. 25% similarity of overlap of lemmas), and so this PR also uses 0.25 as a default.

The `method` attribute is the string name of a clustering method in candidate clustering. This PR relies on `scipy.cluster.hierarchy.linkage` for the hierarchical agglomerative clustering of candidates, and allows users of PTR to specify which clustering method to use. Again, we use the clustering method from the paper as default: "average".

### New methods
The `TopicRank` class is a subclass of `TextRank`, (although it may cause some confusion, as the `TopicRank` implementation also uses the `lemma_graph` object from `TextRank`, but TopicRank uses topic graphs instead). The implementation relies on the overriding of some key methods and properties:
* `node_list`: Now returns a cached (!) list of clustered keyphrase candidates, instead of lemmas.
* `edge_list`: Now returns a list representing edges for a complete, weighted graph between the clustered keyphrase candidates.
* `calc_textrank`: Quite similar to the original, but skips out on some of the post-processing.
* `reset`: Also remove the `node_list` caching.

And two new methods: `_get_candidates` and `_cluster`, which perform steps 2 and 3 of the TopicRank algorithm, respectively (Candidate extraction & Candidate clustering). Note that `_get_candidates` is *almost* just `self.doc.noun_chunks`, but it strips undesired (i.e. `not self._keep_token(token)`) tokens from the candidate keyphrase.

Note that this PR relies on `scipy` and `networkx`, both of which were already dependencies, so this doesn't introduce any additional ones.

### Tests
The tests are based on `test_base.py`, but adapted for TopicRank instead. However, some tests for different `threshold` and `method` values are still missing.

## Other changes
### `conftest.py` changes
Each of the fixtures are now limited to `module`, as the `nlp.add_pipe` from certain tests was preserved between all tests, which led to undesired behaviour (i.e. multiple instances of PTR in the pipeline)

### CI
The continuous integration was updated in this PR. I understand that this is kind of separate to the PR itself, but I felt that the additional tests help give confidence in the correctness. In short, the CI now *first* calls `pre-commit`, and **only** if that passes, it will run `pytest` for Python 3.7, 3.8, 3.9 and 3.10.

## Quirks
There are some implementation details that might require some discussion, and could have different implementations depending on preferences. I'll mention them here, and I'd like to have some discussion about them.
* The `scrubber` attribute is used once, right here: https://github.com/tomaarsen/pytextrank/blob/df5833e463160c740f8d4a920129070e26756950/pytextrank/topicrank.py#L311-L331
  The scrubber is applied **only** on the Phrase `text`, i.e. the keyphrase that "represents" the phrase as a whole. An alternative is to apply the scrubber on **all** keyphrase candidates. 
* In `_get_candidates`, `self._keep_token` is **only** called on the first tokens of a noun chunk, potentially removing those tokens from the noun chunk. If there is a token that we wish to remove at the middle or end of a noun chunk, then it won't be removed. In practice this won't happen often, as it's mostly meant to remove "The" from "The system" etc., but this functionality might be preferred? The current implementation is simpler however, as it doesn't require splitting noun chunks into multiple keyphrase candidates if there is a undesirable token in the middle. There is also an argument to be made that we *usually* want to remove certain tokens, but perhaps not if they occur in the middle of an interesting noun chunk. (i.e. that would be the current implementation)
* Because `TopicRank` extends `TextRank`, but there are some definite differences between them, the inherited `token_lookback` attribute of `TopicRank` is unused. Perhaps a warning if a non-default value is used here would be proper? Alternatively, we could remove this attribute from the `TopicRank` implementation somehow.

## What now?
There are still some TODO's, here are a few:

* As mentioned, I'd still like to add a test or two for `threshold` and `method`.
* On line 88 of `topicrank.py`, there is still a TODO. On e.g. `biasedrank.py`, this place contains a link to https://derwen.ai/docs/ptr/biblio/#kazemi-etal-2020-biased, with the citation for that work. I feel it would be proper to add a citation in the documentation, with a link from the code for TopicRank too. However, I haven't done this as of now.
* If we wish, then there can be some specific documentation for `TopicRank` in PTR, although I don't this has the highest priority. After all, to the end user it'll work almost the same as any of the other ranking components regardless. 

I'd love to hear your thoughts, and if you have any questions or comments, let me know (either here or via Slack). I also have a question for you: is there a specific formatter that you use, that I should use for this work? 

- Tom Aarsen