### PR TITLE
Explicitly catch the InvalidGitRepositoryError when trying to get the repo information.

### DIFF
--- a/pytextrank/version.py
+++ b/pytextrank/version.py
@@ -12,6 +12,7 @@ import pathlib
 import typing
 
 from git import Repo  # pylint: disable=E0401  # type: ignore
+from git.exc import InvalidGitRepositoryError
 
 
 ## use the local Git info for version info, if available
@@ -24,9 +25,8 @@ try:
 
     REPO_HASH = str(repo.head.commit)
     REPO_TAGS = repo.tags
-except Exception as ex:  # pylint: disable=W0703
-    print(ex)
-
+except InvalidGitRepositoryError:
+    pass
 
 # cast version string into a float
 try:


### PR DESCRIPTION
If `pytextrank` is installed via pip, importing `pytextrank` prints out the root directory where it's installed.

### Steps To Reproduce

With Docker using the `python:3.12` image, run:
```
$ pip install pytextrank
$ python -c "import pytextrank"
/usr/local/lib/python3.12/site-packages
$ pip freeze | grep pytextrank
pytextrank==3.3.0
```

### Discussion
The code https://github.com/DerwenAI/pytextrank/blob/5a92184d0b8c4954fcda0a85690e57bf752dd407/pytextrank/version.py#L21-L28 is trying to load git information from the installed location, but since there isn't a git repo there, it just prints the `InvalidGitRepositoryError` exception arguments, which is just a path.

By explicitly catching that exception, it should no longer print out some unnecessary information. This PR will still raise an other unexpected exceptions, though.