### PR TITLE
fix information loss in undirected graph 

### DIFF
--- a/pytextrank/base.py
+++ b/pytextrank/base.py
@@ -498,7 +498,7 @@ Build a list of weighted edges for the lemma graph.
     returns:
 list of weighted edges
         """
-        edges: typing.List[typing.Tuple[Lemma, Lemma]] = []
+        edges: typing.List[typing.Tuple[Lemma, ...]] = []
 
         for sent in self.doc.sents:
             h = [
@@ -510,11 +510,12 @@ list of weighted edges
             for hop in range(self.token_lookback):
                 for idx, node in enumerate(h[: -1 - hop]):
                     nbor = h[hop + idx + 1]
-                    edges.append((node, nbor))
+                    sorted_edge = tuple(sorted([node, nbor], key=lambda x: x.lemma))
+                    edges.append(sorted_edge)
 
         # include weight on the edge: (2, 3, {'weight': 3.1415})
         weighted_edges: typing.List[typing.Tuple[Lemma, Lemma, typing.Dict[str, float]]] = [
-            (*n, {"weight": w * self.edge_weight}) for n, w in Counter(edges).items()
+            (node1, node2, {"weight": w * self.edge_weight}) for (node1,node2), w in Counter(edges).items()
         ]
 
         return weighted_edges

--- a/pytextrank/base.py
+++ b/pytextrank/base.py
@@ -515,7 +515,7 @@ list of weighted edges
 
         # include weight on the edge: (2, 3, {'weight': 3.1415})
         weighted_edges: typing.List[typing.Tuple[Lemma, Lemma, typing.Dict[str, float]]] = [
-            (node1, node2, {"weight": w * self.edge_weight}) for (node1,node2), w in Counter(edges).items()
+            (node1, node2, {"weight": w * self.edge_weight}) for (node1, node2), w in Counter(edges).items()
         ]
 
         return weighted_edges


### PR DESCRIPTION
In an undirected graph, when we add duplicate edges, the associated weight is overwritten instead of accumulated.
As per [networkx documentation](https://networkx.org/documentation/stable/reference/classes/generated/networkx.Graph.add_edges_from.html#networkx.Graph.add_edges_from):

> Adding the same edge twice has no effect but any edge data will be updated when each duplicate edge is added.


For a hypothetical example:
```
weighted_edges = [
    ("play", "with", {'weight': 2.0}),
    ("with", "play", {'weight': 11.0}),
]

graph= nx.Graph()
graph.add_edges_from(weighted_edges)
```
current code leads to(overwriting): 
```
("play", "with", 11.0)
```
Desired behaviour(accumulation): 
```
("play", "with", 13.0)
```
Thanks to @yamika-g for pointing it out [here](https://github.com/DerwenAI/pytextrank/commit/3f61b59aeaaf7f88d6589fc3cb7ab7ccd2bc1ac6#commitcomment-148470736):
